### PR TITLE
[Issue #337] Enhance Http Demo Subscriber by using ExecutorService, CountDownLatch and PreDestroy hook

### DIFF
--- a/eventmesh-test/src/main/java/org/apache/eventmesh/http/demo/AsyncPublishInstance.java
+++ b/eventmesh-test/src/main/java/org/apache/eventmesh/http/demo/AsyncPublishInstance.java
@@ -35,6 +35,9 @@ public class AsyncPublishInstance {
 
     public static Logger logger = LoggerFactory.getLogger(AsyncPublishInstance.class);
 
+    // This messageSize is also used in SubService.java (Subscriber)
+    public static int messageSize = 5;
+
     public static void main(String[] args) throws Exception {
         Properties properties = Utils.readPropertiesFile("application.properties");
         final String eventMeshIp = properties.getProperty("eventmesh.ip");
@@ -62,7 +65,7 @@ public class AsyncPublishInstance {
 
             liteProducer = new LiteProducer(eventMeshClientConfig);
             liteProducer.start();
-            for (int i = 0; i < 5; i++) {
+            for (int i = 0; i < messageSize; i++) {
                 LiteMessage liteMessage = new LiteMessage();
                 liteMessage.setBizSeqNo(RandomStringUtils.randomNumeric(30))
 //                    .setContent("contentStr with special protocal")

--- a/eventmesh-test/src/main/java/org/apache/eventmesh/http/demo/sub/controller/SubController.java
+++ b/eventmesh-test/src/main/java/org/apache/eventmesh/http/demo/sub/controller/SubController.java
@@ -41,11 +41,11 @@ public class SubController {
     @RequestMapping(value = "/test", method = RequestMethod.POST)
     public String subTest(@RequestBody String message) {
         logger.info("=======receive message======= {}", JSONObject.toJSONString(message));
+        subService.consumeMessage(message);
+
         JSONObject result = new JSONObject();
         result.put("retCode", 1);
-        String strResult = result.toJSONString();
-        subService.consumeMessage(strResult);
-        return strResult;
+        return result.toJSONString();
     }
 
 }

--- a/eventmesh-test/src/main/java/org/apache/eventmesh/http/demo/sub/controller/SubController.java
+++ b/eventmesh-test/src/main/java/org/apache/eventmesh/http/demo/sub/controller/SubController.java
@@ -19,8 +19,10 @@ package org.apache.eventmesh.http.demo.sub.controller;
 
 import com.alibaba.fastjson.JSONObject;
 
+import org.apache.eventmesh.http.demo.sub.service.SubService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -33,12 +35,17 @@ public class SubController {
 
     public static Logger logger = LoggerFactory.getLogger(SubController.class);
 
+    @Autowired
+    private SubService subService;
+
     @RequestMapping(value = "/test", method = RequestMethod.POST)
     public String subTest(@RequestBody String message) {
         logger.info("=======receive message======= {}", JSONObject.toJSONString(message));
         JSONObject result = new JSONObject();
         result.put("retCode", 1);
-        return result.toJSONString();
+        String strResult = result.toJSONString();
+        subService.consumeMessage(strResult);
+        return strResult;
     }
 
 }

--- a/eventmesh-test/src/main/java/org/apache/eventmesh/http/demo/sub/service/SubService.java
+++ b/eventmesh-test/src/main/java/org/apache/eventmesh/http/demo/sub/service/SubService.java
@@ -4,9 +4,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.eventmesh.client.http.conf.LiteClientConfig;
 import org.apache.eventmesh.client.http.consumer.LiteConsumer;
@@ -19,7 +16,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Component;
-
 import javax.annotation.PreDestroy;
 
 @Component
@@ -47,8 +43,6 @@ public class SubService implements InitializingBean {
     // CountDownLatch size is the same as messageSize in AsyncPublishInstance.java (Publisher)
     private CountDownLatch countDownLatch = new CountDownLatch(AsyncPublishInstance.messageSize);
 
-    private ExecutorService executorService = Executors.newFixedThreadPool(5);
-
     @Override
     public void afterPropertiesSet() throws Exception {
 
@@ -71,7 +65,7 @@ public class SubService implements InitializingBean {
         liteConsumer.subscribe(topicList, url);
 
         // Wait for all messaged to be consumed
-        executorService.submit(() ->{
+        Thread stopThread = new Thread(() -> {
             try {
                 countDownLatch.await();
             } catch (InterruptedException e) {
@@ -80,6 +74,7 @@ public class SubService implements InitializingBean {
             logger.info("stopThread start....");
             System.exit(0);
         });
+        stopThread.start();
     }
 
     @PreDestroy
@@ -95,7 +90,6 @@ public class SubService implements InitializingBean {
         } catch (Exception e) {
             e.printStackTrace();
         }
-        executorService.shutdown();
         logger.info("end destory.");
     }
 


### PR DESCRIPTION
Enhance Http Demo Subscriber by using ExecutorService, CountDownLatch and PreDestroy hook

- Remove Thread.sleep()
- Leveraging ExecutorService to manage the Thread lifecycle.
- Leveraging PreDestroy annotation to manage the JVM Runtime Shutdown hook