### PR TITLE
[ISSUE #411] Enable CI workflows running on `[0-9]+.[0-9]+.[0-9]+**` branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,11 @@ on:
   push:
     branches:
       - develop
+      - '[0-9]+.[0-9]+.[0-9]+**'
   pull_request:
     branches:
       - develop
+      - '[0-9]+.[0-9]+.[0-9]+**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
See #411.

It worked in the repo I forked.
![image](https://user-images.githubusercontent.com/30497621/123935745-16d96f80-d9c7-11eb-87c0-ff6038ed1645.png)
