### PR TITLE
[To 1.3.0][ISSUE #411] Enable CI workflows running on `[0-9]+.[0-9]+.[0-9]+**` branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,11 @@ on:
   push:
     branches:
       - develop
+      - '[0-9]+.[0-9]+.[0-9]+**'
   pull_request:
     branches:
       - develop
+      - '[0-9]+.[0-9]+.[0-9]+**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
See #411.