### PR TITLE
[ISSUE #442] update checkStyle file

### DIFF
--- a/style/checkStyle.xml
+++ b/style/checkStyle.xml
@@ -51,8 +51,4 @@
     </module>
   </module>
 
-  <module name="BeforeExecutionExclusionFileFilter">
-    <property name="fileNamePattern" value="./eventmesh-runtime/conf/sChat2.jks$"/>
-  </module>
-
 </module>


### PR DESCRIPTION
Since the `sChat2.jks` has been removed, we can remove the filter.