### PR TITLE
[ISSUE #375] In memory as event store

### DIFF
--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/build.gradle
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/build.gradle
@@ -15,19 +15,8 @@
  * limitations under the License.
  */
 
-rootProject.name = 'EventMesh'
-String jdkVersion = "${jdk}"
-include 'eventmesh-runtime'
-include 'eventmesh-sdk-java'
-include 'eventmesh-common'
-include 'eventmesh-starter'
-include 'eventmesh-test'
-include 'eventmesh-spi'
-include 'eventmesh-connector-plugin:eventmesh-connector-api'
-include 'eventmesh-connector-plugin:eventmesh-connector-rocketmq'
-include 'eventmesh-connector-plugin:eventmesh-connector-standalone'
-include 'eventmesh-security-plugin:eventmesh-security-api'
-include 'eventmesh-security-plugin:eventmesh-security-acl'
-include 'eventmesh-registry-plugin:eventmesh-registry-api'
-include 'eventmesh-registry-plugin:eventmesh-registry-rocketmq-namesrv'
+dependencies {
+    api project(":eventmesh-connector-plugin:eventmesh-connector-api")
 
+    testImplementation project(":eventmesh-connector-plugin:eventmesh-connector-api")
+}

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/gradle.properties
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/gradle.properties
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/MessagingAccessPointImpl.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/MessagingAccessPointImpl.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.connector.standalone;
+
+import io.openmessaging.api.Consumer;
+import io.openmessaging.api.MessagingAccessPoint;
+import io.openmessaging.api.Producer;
+import io.openmessaging.api.PullConsumer;
+import io.openmessaging.api.batch.BatchConsumer;
+import io.openmessaging.api.order.OrderConsumer;
+import io.openmessaging.api.order.OrderProducer;
+import io.openmessaging.api.transaction.LocalTransactionChecker;
+import io.openmessaging.api.transaction.TransactionProducer;
+import org.apache.eventmesh.connector.standalone.consumer.StandaloneConsumer;
+import org.apache.eventmesh.connector.standalone.producer.StandaloneProducer;
+
+import java.util.Properties;
+
+public class MessagingAccessPointImpl implements MessagingAccessPoint {
+
+    private Properties accessPointProperties;
+
+    public MessagingAccessPointImpl(Properties accessPointProperties) {
+        this.accessPointProperties = accessPointProperties;
+    }
+
+    @Override
+    public String version() {
+        return null;
+    }
+
+    @Override
+    public Properties attributes() {
+        return accessPointProperties;
+    }
+
+    @Override
+    public Producer createProducer(Properties properties) {
+        return new StandaloneProducer(properties);
+    }
+
+    @Override
+    public OrderProducer createOrderProducer(Properties properties) {
+        return null;
+    }
+
+    @Override
+    public TransactionProducer createTransactionProducer(Properties properties, LocalTransactionChecker checker) {
+        return null;
+    }
+
+    @Override
+    public TransactionProducer createTransactionProducer(Properties properties) {
+        return null;
+    }
+
+    @Override
+    public Consumer createConsumer(Properties properties) {
+        return new StandaloneConsumer(properties);
+    }
+
+    @Override
+    public PullConsumer createPullConsumer(Properties properties) {
+        return null;
+    }
+
+    @Override
+    public BatchConsumer createBatchConsumer(Properties properties) {
+        return null;
+    }
+
+    @Override
+    public OrderConsumer createOrderedConsumer(Properties properties) {
+        return null;
+    }
+}

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/broker/MessageQueue.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/broker/MessageQueue.java
@@ -37,11 +37,11 @@ public class MessageQueue {
 
     private int count;
 
-    private ReentrantLock lock;
+    private final ReentrantLock lock;
 
-    private Condition notEmpty;
+    private final Condition notEmpty;
 
-    private Condition notFull;
+    private final Condition notFull;
 
 
     public MessageQueue() {

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/broker/MessageQueue.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/broker/MessageQueue.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.connector.standalone.broker;
+
+import com.google.common.base.Preconditions;
+import org.apache.eventmesh.connector.standalone.broker.model.MessageEntity;
+
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * This is a block queue, can get entity by offset.
+ * The queue is a FIFO data structure.
+ */
+public class MessageQueue {
+
+    public MessageEntity[] items;
+
+    private int takeIndex;
+
+    private int putIndex;
+
+    private int count;
+
+    private ReentrantLock lock;
+
+    private Condition notEmpty;
+
+    private Condition notFull;
+
+
+    public MessageQueue() {
+        this(2 << 10);
+    }
+
+    public MessageQueue(int capacity) {
+        if (capacity <= 0) {
+            throw new IllegalArgumentException("capacity is illegal");
+        }
+        this.items = new MessageEntity[capacity];
+        this.lock = new ReentrantLock();
+        this.notEmpty = lock.newCondition();
+        this.notFull = lock.newCondition();
+    }
+
+    /**
+     * Insert the message at the tail of this queue, waiting for space to become available if the queue is full
+     *
+     * @param messageEntity
+     */
+    public void put(MessageEntity messageEntity) throws InterruptedException {
+        Preconditions.checkNotNull(messageEntity);
+        ReentrantLock lock = this.lock;
+        lock.lockInterruptibly();
+        try {
+            while (count == items.length) {
+                notFull.await();
+            }
+            enqueue(messageEntity);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Get the first message at this queue, waiting for the message is available if the queue is empty,
+     * this method will not remove the message
+     *
+     * @return
+     * @throws InterruptedException
+     */
+    public MessageEntity take() throws InterruptedException {
+        ReentrantLock lock = this.lock;
+        lock.lockInterruptibly();
+        try {
+            while (count == 0) {
+                notEmpty.await();
+            }
+            return dequeue();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Get the first message at this queue, if the queue is empty return null immediately
+     *
+     * @return
+     */
+    public MessageEntity peek() {
+        ReentrantLock lock = this.lock;
+        lock.lock();
+        try {
+            return itemAt(takeIndex);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Get the head in this queue
+     *
+     * @return
+     */
+    public MessageEntity getHead() {
+        return peek();
+    }
+
+    /**
+     * Get the tail in this queue
+     *
+     * @return
+     */
+    public MessageEntity getTail() {
+        ReentrantLock lock = this.lock;
+        lock.lock();
+        try {
+            if (count == 0) {
+                return null;
+            }
+            int tailIndex = putIndex - 1;
+            if (tailIndex < 0) {
+                tailIndex += items.length;
+            }
+            return itemAt(tailIndex);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Get the message by offset, since the offset is increment, so we can get the first message in this queue
+     * and calculate the index of this offset
+     *
+     * @param offset
+     * @return
+     */
+    public MessageEntity getByOffset(long offset) {
+        ReentrantLock lock = this.lock;
+        lock.lock();
+        try {
+            MessageEntity head = getHead();
+            if (head == null) {
+                return null;
+            }
+            if (head.getOffset() > offset) {
+                throw new RuntimeException(String.format("The message has been deleted, offset: %s", offset));
+            }
+            MessageEntity tail = getTail();
+            if (tail == null || tail.getOffset() < offset) {
+                throw new RuntimeException(String.format("The offset: %s is invalidated", offset));
+            }
+            int offsetDis = (int) (tail.getOffset() - offset);
+            int offsetIndex = takeIndex - 1 - offsetDis;
+            if (offsetIndex < 0) {
+                offsetIndex += items.length;
+            }
+            return itemAt(offsetIndex);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void removeHead() {
+        ReentrantLock lock = this.lock;
+        lock.lock();
+        try {
+            if (count == 0) {
+                return;
+            }
+            items[takeIndex++] = null;
+            if (takeIndex == items.length) {
+                takeIndex = 0;
+            }
+            notFull.signal();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+
+    private MessageEntity itemAt(int index) {
+        return items[index];
+    }
+
+    private void enqueue(MessageEntity messageEntity) {
+        items[putIndex++] = messageEntity;
+        if (putIndex == items.length) {
+            putIndex = 0;
+        }
+        count++;
+        notEmpty.signal();
+    }
+
+    private MessageEntity dequeue() {
+        MessageEntity item = items[takeIndex++];
+        if (takeIndex == items.length) {
+            takeIndex = 0;
+        }
+        notFull.signal();
+        return item;
+    }
+
+}

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/broker/MessageQueue.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/broker/MessageQueue.java
@@ -163,10 +163,10 @@ public class MessageQueue {
             }
             MessageEntity tail = getTail();
             if (tail == null || tail.getOffset() < offset) {
-                throw new RuntimeException(String.format("The offset: %s is invalidated", offset));
+                return null;
             }
-            int offsetDis = (int) (tail.getOffset() - offset);
-            int offsetIndex = takeIndex - 1 - offsetDis;
+            int offsetDis = (int) (head.getOffset() - offset);
+            int offsetIndex = takeIndex - offsetDis;
             if (offsetIndex < 0) {
                 offsetIndex += items.length;
             }
@@ -191,6 +191,10 @@ public class MessageQueue {
         } finally {
             lock.unlock();
         }
+    }
+
+    public int getSize() {
+        return count;
     }
 
 

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/broker/StandaloneBroker.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/broker/StandaloneBroker.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.connector.standalone.broker;
+
+import io.openmessaging.api.Message;
+import org.apache.eventmesh.connector.standalone.broker.model.MessageEntity;
+import org.apache.eventmesh.connector.standalone.broker.model.TopicMetadata;
+import org.apache.eventmesh.connector.standalone.broker.task.HistoryMessageClearTask;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * This broker used to store event, it just support standalone mode, you shouldn't use this module in production environment
+ */
+public class StandaloneBroker {
+
+    private final ConcurrentHashMap<TopicMetadata, MessageQueue> messageContainer;
+
+    // todo: move the offset manage to consumer
+    private final ConcurrentHashMap<TopicMetadata, AtomicLong> offsetMap;
+
+    private StandaloneBroker() {
+        this.messageContainer = new ConcurrentHashMap<>();
+        this.offsetMap = new ConcurrentHashMap<>();
+        startHistoryMessageCleanTask();
+    }
+
+    public static StandaloneBroker getInstance() {
+        return StandaloneBrokerInstanceHolder.instance;
+    }
+
+    /**
+     * put message
+     *
+     * @param topicName topic name
+     * @param message   message
+     * @throws InterruptedException
+     */
+    public MessageEntity putMessage(String topicName, Message message) throws InterruptedException {
+        TopicMetadata topicMetadata = new TopicMetadata(topicName);
+        AtomicLong topicOffset = offsetMap.computeIfAbsent(topicMetadata, k -> new AtomicLong());
+        MessageEntity messageEntity = new MessageEntity(topicMetadata, message, topicOffset.getAndIncrement(), System.currentTimeMillis());
+        messageContainer.computeIfAbsent(topicMetadata, k -> new MessageQueue()).put(messageEntity);
+
+        return messageEntity;
+    }
+
+    /**
+     * Get the message, if the queue is empty then await
+     *
+     * @param topicName
+     */
+    public Message takeMessage(String topicName) throws InterruptedException {
+        TopicMetadata topicMetadata = new TopicMetadata(topicName);
+        return messageContainer.computeIfAbsent(topicMetadata, k -> new MessageQueue()).take().getMessage();
+    }
+
+    /**
+     * Get the message, if the queue is empty return null
+     *
+     * @param topicName
+     */
+    public Message getMessage(String topicName) {
+        TopicMetadata topicMetadata = new TopicMetadata(topicName);
+        MessageEntity head = messageContainer.computeIfAbsent(topicMetadata, k -> new MessageQueue()).getHead();
+        if (head == null) {
+            return null;
+        }
+        return head.getMessage();
+    }
+
+    /**
+     * Get the message by offset
+     *
+     * @param topicName topic name
+     * @param offset    offset
+     * @return
+     */
+    public Message getMessage(String topicName, long offset) {
+        TopicMetadata topicMetadata = new TopicMetadata(topicName);
+        MessageEntity messageEntity = messageContainer.computeIfAbsent(topicMetadata, k -> new MessageQueue()).getByOffset(offset);
+        if (messageEntity == null) {
+            return null;
+        }
+        return messageEntity.getMessage();
+    }
+
+
+    private void startHistoryMessageCleanTask() {
+        Thread thread = new Thread(new HistoryMessageClearTask(messageContainer));
+        thread.setDaemon(true);
+        thread.setName("StandaloneBroker-HistoryMessageCleanTask");
+        thread.start();
+    }
+
+    public boolean checkTopicExist(String topicName) {
+        return messageContainer.containsKey(topicName);
+    }
+
+    public void updateOffset(TopicMetadata topicMetadata, long offset) {
+        offsetMap.computeIfPresent(topicMetadata, (k, v) -> {
+            v.set(offset);
+            return v;
+        });
+    }
+
+    private static class StandaloneBrokerInstanceHolder {
+        private static final StandaloneBroker instance = new StandaloneBroker();
+    }
+}

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/broker/model/MessageEntity.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/broker/model/MessageEntity.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.connector.standalone.broker.model;
+
+import io.openmessaging.api.Message;
+
+import java.io.Serializable;
+
+public class MessageEntity implements Serializable {
+
+    private TopicMetadata topicMetadata;
+
+    private Message message;
+
+    private long offset;
+
+    private long createTimeMills;
+
+    public MessageEntity(TopicMetadata topicMetadata, Message message, long offset, long currentTimeMills) {
+        this.topicMetadata = topicMetadata;
+        this.message = message;
+        this.offset = offset;
+        this.createTimeMills = currentTimeMills;
+    }
+
+    public TopicMetadata getTopicMetadata() {
+        return topicMetadata;
+    }
+
+    public void setTopicMetadata(TopicMetadata topicMetadata) {
+        this.topicMetadata = topicMetadata;
+    }
+
+    public Message getMessage() {
+        return message;
+    }
+
+    public void setMessage(Message message) {
+        this.message = message;
+    }
+
+    public long getOffset() {
+        return offset;
+    }
+
+    public void setOffset(long offset) {
+        this.offset = offset;
+    }
+
+    public long getCreateTimeMills() {
+        return createTimeMills;
+    }
+
+    public void setCreateTimeMills(long createTimeMills) {
+        this.createTimeMills = createTimeMills;
+    }
+}

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/broker/model/TopicMetadata.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/broker/model/TopicMetadata.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.connector.standalone.broker.model;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Topic metadata, each topic has it's own metadata
+ */
+public class TopicMetadata implements Serializable {
+
+    private String topicName;
+
+    public TopicMetadata(String topicName) {
+        this.topicName = topicName;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TopicMetadata)) {
+            return false;
+        }
+        TopicMetadata that = (TopicMetadata) o;
+        return Objects.equals(topicName, that.topicName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(topicName);
+    }
+
+    @Override
+    public String toString() {
+        return "TopicMetadata{" +
+                "topic='" + topicName + '\'' +
+                '}';
+    }
+}

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/broker/task/HistoryMessageClearTask.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/broker/task/HistoryMessageClearTask.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.connector.standalone.broker.task;
+
+import org.apache.eventmesh.connector.standalone.broker.MessageQueue;
+import org.apache.eventmesh.connector.standalone.broker.model.MessageEntity;
+import org.apache.eventmesh.connector.standalone.broker.model.TopicMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This task used to clear the history message, the element in message queue can only be cleaned by this task.
+ */
+public class HistoryMessageClearTask implements Runnable {
+
+
+    private final Logger logger = LoggerFactory.getLogger(HistoryMessageClearTask.class);
+
+    private final ConcurrentHashMap<TopicMetadata, MessageQueue> messageContainer;
+
+    /**
+     * If the currentTimeMills - messageCreateTimeMills >= MESSAGE_STORE_WINDOW, then the message will be clear
+     */
+    private final long MESSAGE_STORE_WINDOW = 60 * 60 * 1000;
+
+    public HistoryMessageClearTask(ConcurrentHashMap<TopicMetadata, MessageQueue> messageContainer) {
+        this.messageContainer = messageContainer;
+    }
+
+    @Override
+    public void run() {
+        while (true) {
+            messageContainer.forEach((topicMetadata, messageQueue) -> {
+                long currentTimeMillis = System.currentTimeMillis();
+                MessageEntity oldestMessage = messageQueue.getHead();
+                if (oldestMessage == null) {
+                    return;
+                }
+                if (currentTimeMillis - oldestMessage.getCreateTimeMills() >= MESSAGE_STORE_WINDOW) {
+                    messageQueue.removeHead();
+                }
+            });
+            try {
+                Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+            } catch (InterruptedException e) {
+                logger.error("Thread is interrupted, thread name: {}", Thread.currentThread().getName(), e);
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/broker/task/SubScribeTask.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/broker/task/SubScribeTask.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.connector.standalone.broker.task;
+
+import io.openmessaging.api.AsyncMessageListener;
+import io.openmessaging.api.Message;
+import org.apache.eventmesh.api.EventMeshAction;
+import org.apache.eventmesh.api.EventMeshAsyncConsumeContext;
+import org.apache.eventmesh.connector.standalone.broker.StandaloneBroker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SubScribeTask implements Runnable {
+
+    private String               topicName;
+    private StandaloneBroker     standaloneBroker;
+    private AsyncMessageListener listener;
+    private AtomicBoolean        isRunning;
+
+    private AtomicInteger offset;
+
+    private final Logger logger = LoggerFactory.getLogger(SubScribeTask.class);
+
+    public SubScribeTask(String topicName,
+                         StandaloneBroker standaloneBroker,
+                         AsyncMessageListener listener) {
+        this.topicName = topicName;
+        this.standaloneBroker = standaloneBroker;
+        this.listener = listener;
+        isRunning = new AtomicBoolean(true);
+    }
+
+    @Override
+    public void run() {
+        while (isRunning.get()) {
+            try {
+                if (offset == null) {
+                    Message message = standaloneBroker.getMessage(topicName);
+                    if (message != null) {
+                        offset = new AtomicInteger((int) message.getOffset());
+                    }
+                }
+                if (offset == null) {
+                    return;
+                }
+
+                Message message = standaloneBroker.getMessage(topicName, offset.get());
+                EventMeshAsyncConsumeContext consumeContext = new EventMeshAsyncConsumeContext() {
+                    @Override
+                    public void commit(EventMeshAction action) {
+                        switch (action) {
+                            case CommitMessage:
+                                // update offset
+                                offset.incrementAndGet();
+                                logger.info("message commit, topic: {}, current offset:{}", topicName, offset.get());
+                                break;
+                            case ReconsumeLater:
+                                // don't update offset
+                                break;
+                            case ManualAck:
+                                // update offset
+                                offset.incrementAndGet();
+                                logger.info("message ack, topic: {}, current offset:{}", topicName, offset.get());
+                                break;
+                            default:
+
+                        }
+                    }
+                };
+                listener.consume(message, consumeContext);
+            } catch (Exception ex) {
+                logger.error("consumer error, topic: {}, offset: {}", topicName, offset == null ? null : offset.get(), ex);
+            }
+            try {
+                Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+            } catch (InterruptedException e) {
+                logger.error("Thread is interrupted, topic: {}, offset: {} thread name: {}",
+                        topicName, offset == null ? null : offset.get(), Thread.currentThread().getName(), e);
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    public void shutdown() {
+        isRunning.compareAndSet(true, false);
+    }
+
+}

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/broker/task/SubScribeTask.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/broker/task/SubScribeTask.java
@@ -69,7 +69,6 @@ public class SubScribeTask implements Runnable {
                                 switch (action) {
                                     case CommitMessage:
                                         // update offset
-                                        offset.incrementAndGet();
                                         logger.info("message commit, topic: {}, current offset:{}", topicName, offset.get());
                                         break;
                                     case ReconsumeLater:

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/consumer/StandaloneConsumer.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/consumer/StandaloneConsumer.java
@@ -1,0 +1,131 @@
+package org.apache.eventmesh.connector.standalone.consumer;
+
+import io.openmessaging.api.AsyncGenericMessageListener;
+import io.openmessaging.api.AsyncMessageListener;
+import io.openmessaging.api.Consumer;
+import io.openmessaging.api.GenericMessageListener;
+import io.openmessaging.api.Message;
+import io.openmessaging.api.MessageListener;
+import io.openmessaging.api.MessageSelector;
+import org.apache.eventmesh.common.ThreadPoolFactory;
+import org.apache.eventmesh.connector.standalone.broker.StandaloneBroker;
+import org.apache.eventmesh.connector.standalone.broker.model.TopicMetadata;
+import org.apache.eventmesh.connector.standalone.broker.task.SubScribeTask;
+
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class StandaloneConsumer implements Consumer {
+
+    private StandaloneBroker standaloneBroker;
+
+    private AtomicBoolean isStarted;
+
+    private ConcurrentHashMap<String, AsyncMessageListener> subscribeTable;
+
+    private ConcurrentHashMap<String, SubScribeTask> subscribeTaskTable;
+
+    private ExecutorService consumeExecutorService;
+
+    public StandaloneConsumer(Properties properties) {
+        this.standaloneBroker = StandaloneBroker.getInstance();
+        this.subscribeTable = new ConcurrentHashMap<>(16);
+        this.subscribeTaskTable = new ConcurrentHashMap<>(16);
+        this.isStarted = new AtomicBoolean(false);
+        consumeExecutorService = ThreadPoolFactory.createThreadPoolExecutor(
+                Runtime.getRuntime().availableProcessors() * 2,
+                Runtime.getRuntime().availableProcessors() * 2,
+                "StandaloneConsumerThread"
+        );
+    }
+
+    @Override
+    public void subscribe(String topic, String subExpression, MessageListener listener) {
+    }
+
+    @Override
+    public void subscribe(String topic, MessageSelector selector, MessageListener listener) {
+    }
+
+    @Override
+    public <T> void subscribe(String topic, String subExpression, GenericMessageListener<T> listener) {
+    }
+
+    @Override
+    public <T> void subscribe(String topic, MessageSelector selector, GenericMessageListener<T> listener) {
+    }
+
+    @Override
+    public void subscribe(String topic, String subExpression, AsyncMessageListener listener) {
+        if (isClosed()) {
+            return;
+        }
+        if (subscribeTable.containsKey(topic)) {
+            return;
+        }
+        subscribeTable.put(topic, listener);
+        SubScribeTask subScribeTask = new SubScribeTask(topic, standaloneBroker, listener);
+        subscribeTaskTable.put(topic, subScribeTask);
+        consumeExecutorService.submit(subScribeTask);
+    }
+
+    @Override
+    public void subscribe(String topic, MessageSelector selector, AsyncMessageListener listener) {
+    }
+
+    @Override
+    public <T> void subscribe(String topic, String subExpression, AsyncGenericMessageListener<T> listener) {
+    }
+
+    @Override
+    public <T> void subscribe(String topic, MessageSelector selector, AsyncGenericMessageListener<T> listener) {
+    }
+
+    @Override
+    public void unsubscribe(String topic) {
+        if (isClosed()) {
+            return;
+        }
+        if (!subscribeTable.containsKey(topic)) {
+            return;
+        }
+        subscribeTable.remove(topic);
+        SubScribeTask subScribeTask = subscribeTaskTable.get(topic);
+        subScribeTask.shutdown();
+        subscribeTaskTable.remove(topic);
+    }
+
+    @Override
+    public void updateCredential(Properties credentialProperties) {
+
+    }
+
+    @Override
+    public boolean isStarted() {
+        return isStarted.get();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return !isStarted.get();
+    }
+
+    @Override
+    public void start() {
+        isStarted.compareAndSet(false, true);
+    }
+
+    @Override
+    public void shutdown() {
+        isStarted.compareAndSet(true, false);
+        subscribeTable.clear();
+        subscribeTaskTable.forEach(((topic, subScribeTask) -> subScribeTask.shutdown()));
+        subscribeTaskTable.clear();
+    }
+
+    public void updateOffset(Message message) {
+        standaloneBroker.updateOffset(new TopicMetadata(message.getTopic()), message.getOffset());
+    }
+}

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/consumer/StandaloneConsumer.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/consumer/StandaloneConsumer.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.eventmesh.connector.standalone.consumer;
 
 import io.openmessaging.api.AsyncGenericMessageListener;

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/consumer/StandaloneMeshMQPushConsumerAdaptor.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/consumer/StandaloneMeshMQPushConsumerAdaptor.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.eventmesh.connector.standalone.consumer;
 
 import io.openmessaging.api.AsyncGenericMessageListener;

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/consumer/StandaloneMeshMQPushConsumerAdaptor.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/consumer/StandaloneMeshMQPushConsumerAdaptor.java
@@ -1,0 +1,118 @@
+package org.apache.eventmesh.connector.standalone.consumer;
+
+import io.openmessaging.api.AsyncGenericMessageListener;
+import io.openmessaging.api.AsyncMessageListener;
+import io.openmessaging.api.GenericMessageListener;
+import io.openmessaging.api.Message;
+import io.openmessaging.api.MessageListener;
+import io.openmessaging.api.MessageSelector;
+import org.apache.eventmesh.api.AbstractContext;
+import org.apache.eventmesh.api.consumer.MeshMQPushConsumer;
+import org.apache.eventmesh.connector.standalone.MessagingAccessPointImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Properties;
+
+public class StandaloneMeshMQPushConsumerAdaptor implements MeshMQPushConsumer {
+
+    private final Logger logger = LoggerFactory.getLogger(StandaloneMeshMQPushConsumerAdaptor.class);
+
+    private StandaloneConsumer consumer;
+
+    public StandaloneMeshMQPushConsumerAdaptor() {
+    }
+
+    @Override
+    public void init(Properties keyValue) throws Exception {
+        String producerGroup = keyValue.getProperty("producerGroup");
+
+        MessagingAccessPointImpl messagingAccessPoint = new MessagingAccessPointImpl(keyValue);
+        consumer = (StandaloneConsumer) messagingAccessPoint.createConsumer(keyValue);
+
+    }
+
+    @Override
+    public void updateOffset(List<Message> msgs, AbstractContext context) {
+        for(Message message : msgs) {
+            consumer.updateOffset(message);
+        }
+    }
+
+    @Override
+    public void subscribe(String topic, AsyncMessageListener listener) throws Exception {
+        // todo: support subExpression
+        consumer.subscribe(topic, "*", listener);
+    }
+
+    @Override
+    public void unsubscribe(String topic) {
+        consumer.unsubscribe(topic);
+    }
+
+    @Override
+    public void subscribe(String topic, String subExpression, MessageListener listener) {
+        throw new UnsupportedOperationException("not supported yet");
+    }
+
+    @Override
+    public void subscribe(String topic, MessageSelector selector, MessageListener listener) {
+        throw new UnsupportedOperationException("not supported yet");
+    }
+
+    @Override
+    public <T> void subscribe(String topic, String subExpression, GenericMessageListener<T> listener) {
+        throw new UnsupportedOperationException("not supported yet");
+    }
+
+    @Override
+    public <T> void subscribe(String topic, MessageSelector selector, GenericMessageListener<T> listener) {
+        throw new UnsupportedOperationException("not supported yet");
+    }
+
+    @Override
+    public void subscribe(String topic, String subExpression, AsyncMessageListener listener) {
+        throw new UnsupportedOperationException("not supported yet");
+    }
+
+    @Override
+    public void subscribe(String topic, MessageSelector selector, AsyncMessageListener listener) {
+        throw new UnsupportedOperationException("not supported yet");
+    }
+
+    @Override
+    public <T> void subscribe(String topic, String subExpression, AsyncGenericMessageListener<T> listener) {
+        throw new UnsupportedOperationException("not supported yet");
+    }
+
+    @Override
+    public <T> void subscribe(String topic, MessageSelector selector, AsyncGenericMessageListener<T> listener) {
+        throw new UnsupportedOperationException("not supported yet");
+    }
+
+    @Override
+    public void updateCredential(Properties credentialProperties) {
+
+    }
+
+    @Override
+    public boolean isStarted() {
+        return consumer.isStarted();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return consumer.isClosed();
+    }
+
+    @Override
+    public void start() {
+        consumer.start();
+    }
+
+    @Override
+    public void shutdown() {
+        consumer.shutdown();
+    }
+}

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/producer/StandaloneMeshMQProducerAdaptor.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/producer/StandaloneMeshMQProducerAdaptor.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.connector.standalone.producer;
+
+import io.openmessaging.api.Message;
+import io.openmessaging.api.MessageBuilder;
+import io.openmessaging.api.SendCallback;
+import io.openmessaging.api.SendResult;
+import org.apache.eventmesh.api.RRCallback;
+import org.apache.eventmesh.api.producer.MeshMQProducer;
+import org.apache.eventmesh.connector.standalone.MessagingAccessPointImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+
+public class StandaloneMeshMQProducerAdaptor implements MeshMQProducer {
+
+    private final Logger logger = LoggerFactory.getLogger(StandaloneMeshMQProducerAdaptor.class);
+
+    private StandaloneProducer standaloneProducer;
+
+    public StandaloneMeshMQProducerAdaptor() {
+    }
+
+    @Override
+    public void init(Properties properties) throws Exception {
+        MessagingAccessPointImpl messagingAccessPoint = new MessagingAccessPointImpl(properties);
+        standaloneProducer = (StandaloneProducer) messagingAccessPoint.createProducer(properties);
+    }
+
+    @Override
+    public void send(Message message, SendCallback sendCallback) throws Exception {
+        standaloneProducer.sendAsync(message, sendCallback);
+    }
+
+    @Override
+    public void request(Message message, SendCallback sendCallback, RRCallback rrCallback, long timeout) throws Exception {
+        throw new UnsupportedOperationException("not support request-reply mode when eventstore=standalone");
+    }
+
+    @Override
+    public Message request(Message message, long timeout) throws Exception {
+        throw new UnsupportedOperationException("not support request-reply mode when eventstore=standalone");
+    }
+
+    @Override
+    public boolean reply(Message message, SendCallback sendCallback) throws Exception {
+        throw new UnsupportedOperationException("not support request-reply mode when eventstore=standalone");
+    }
+
+    @Override
+    public void checkTopicExist(String topic) throws Exception {
+        boolean exist = standaloneProducer.checkTopicExist(topic);
+        if (!exist) {
+            throw new RuntimeException(String.format("topic:%s is not exist", topic));
+        }
+    }
+
+    @Override
+    public void setExtFields() {
+
+    }
+
+    @Override
+    public SendResult send(Message message) {
+        return standaloneProducer.send(message);
+    }
+
+    @Override
+    public void sendOneway(Message message) {
+        standaloneProducer.sendOneway(message);
+    }
+
+    @Override
+    public void sendAsync(Message message, SendCallback sendCallback) {
+        standaloneProducer.sendAsync(message, sendCallback);
+    }
+
+    @Override
+    public void setCallbackExecutor(ExecutorService callbackExecutor) {
+        standaloneProducer.setCallbackExecutor(callbackExecutor);
+    }
+
+    @Override
+    public void updateCredential(Properties credentialProperties) {
+        standaloneProducer.updateCredential(credentialProperties);
+    }
+
+    @Override
+    public boolean isStarted() {
+        return standaloneProducer.isStarted();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return standaloneProducer.isClosed();
+    }
+
+    @Override
+    public void start() {
+        standaloneProducer.start();
+    }
+
+    @Override
+    public void shutdown() {
+        standaloneProducer.shutdown();
+    }
+
+    @Override
+    public <T> MessageBuilder<T> messageBuilder() {
+        return null;
+    }
+}

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/producer/StandaloneMeshMQProducerAdaptor.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/producer/StandaloneMeshMQProducerAdaptor.java
@@ -51,12 +51,7 @@ public class StandaloneMeshMQProducerAdaptor implements MeshMQProducer {
     }
 
     @Override
-    public void request(Message message, SendCallback sendCallback, RRCallback rrCallback, long timeout) throws Exception {
-        throw new UnsupportedOperationException("not support request-reply mode when eventstore=standalone");
-    }
-
-    @Override
-    public Message request(Message message, long timeout) throws Exception {
+    public void request(Message message, RRCallback rrCallback, long timeout) throws Exception {
         throw new UnsupportedOperationException("not support request-reply mode when eventstore=standalone");
     }
 

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/producer/StandaloneProducer.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/producer/StandaloneProducer.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.connector.standalone.producer;
+
+import com.google.common.base.Preconditions;
+import io.openmessaging.api.Message;
+import io.openmessaging.api.MessageBuilder;
+import io.openmessaging.api.OnExceptionContext;
+import io.openmessaging.api.Producer;
+import io.openmessaging.api.SendCallback;
+import io.openmessaging.api.SendResult;
+import io.openmessaging.api.exception.OMSRuntimeException;
+import org.apache.eventmesh.connector.standalone.broker.StandaloneBroker;
+import org.apache.eventmesh.connector.standalone.broker.model.MessageEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class StandaloneProducer implements Producer {
+
+    private Logger logger = LoggerFactory.getLogger(StandaloneProducer.class);
+
+    private StandaloneBroker standaloneBroker;
+
+    private AtomicBoolean isStarted;
+
+    public StandaloneProducer(Properties properties) {
+        this.standaloneBroker = StandaloneBroker.getInstance();
+        this.isStarted = new AtomicBoolean(false);
+    }
+
+    @Override
+    public SendResult send(Message message) {
+        Preconditions.checkNotNull(message);
+        try {
+            MessageEntity messageEntity = standaloneBroker.putMessage(message.getTopic(), message);
+            SendResult sendResult = new SendResult();
+            sendResult.setTopic(message.getTopic());
+            sendResult.setMessageId(String.valueOf(messageEntity.getOffset()));
+            return sendResult;
+        } catch (Exception e) {
+            logger.error("send message error, topic: {}", message.getTopic(), e);
+            throw new OMSRuntimeException(String.format("Send message error, topic: %s", message.getTopic()));
+        }
+    }
+
+    @Override
+    public void sendOneway(Message message) {
+        send(message);
+    }
+
+    @Override
+    public void sendAsync(Message message, SendCallback sendCallback) {
+        Preconditions.checkNotNull(message);
+        Preconditions.checkNotNull(sendCallback);
+
+        try {
+            SendResult sendResult = send(message);
+            sendCallback.onSuccess(sendResult);
+        } catch (Exception ex) {
+            OnExceptionContext exceptionContext = new OnExceptionContext();
+            exceptionContext.setTopic(message.getTopic());
+            exceptionContext.setException(new OMSRuntimeException(ex));
+            exceptionContext.setMessageId(message.getMsgID());
+            sendCallback.onException(exceptionContext);
+        }
+
+    }
+
+    @Override
+    public void setCallbackExecutor(ExecutorService callbackExecutor) {
+
+    }
+
+    @Override
+    public void updateCredential(Properties credentialProperties) {
+
+    }
+
+    @Override
+    public boolean isStarted() {
+        return isStarted.get();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return !isStarted.get();
+    }
+
+    @Override
+    public void start() {
+        isStarted.compareAndSet(false, true);
+    }
+
+    @Override
+    public void shutdown() {
+        isStarted.compareAndSet(true, false);
+
+    }
+
+    @Override
+    public <T> MessageBuilder<T> messageBuilder() {
+        return null;
+    }
+
+    public boolean checkTopicExist(String topicName) {
+        return standaloneBroker.checkTopicExist(topicName);
+    }
+}

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/resource/StandaloneConnectorResourceService.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/resource/StandaloneConnectorResourceService.java
@@ -15,19 +15,19 @@
  * limitations under the License.
  */
 
-rootProject.name = 'EventMesh'
-String jdkVersion = "${jdk}"
-include 'eventmesh-runtime'
-include 'eventmesh-sdk-java'
-include 'eventmesh-common'
-include 'eventmesh-starter'
-include 'eventmesh-test'
-include 'eventmesh-spi'
-include 'eventmesh-connector-plugin:eventmesh-connector-api'
-include 'eventmesh-connector-plugin:eventmesh-connector-rocketmq'
-include 'eventmesh-connector-plugin:eventmesh-connector-standalone'
-include 'eventmesh-security-plugin:eventmesh-security-api'
-include 'eventmesh-security-plugin:eventmesh-security-acl'
-include 'eventmesh-registry-plugin:eventmesh-registry-api'
-include 'eventmesh-registry-plugin:eventmesh-registry-rocketmq-namesrv'
+package org.apache.eventmesh.connector.standalone.resource;
 
+import org.apache.eventmesh.api.connector.ConnectorResourceService;
+
+public class StandaloneConnectorResourceService implements ConnectorResourceService {
+
+    @Override
+    public void init() throws Exception {
+
+    }
+
+    @Override
+    public void release() throws Exception {
+
+    }
+}

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/resources/META-INF/eventmesh/org.apache.eventmesh.api.connector.ConnectorResourceService
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/resources/META-INF/eventmesh/org.apache.eventmesh.api.connector.ConnectorResourceService
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+standalone=org.apache.eventmesh.connector.standalone.resource.StandaloneConnectorResourceService

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/resources/META-INF/eventmesh/org.apache.eventmesh.api.consumer.MeshMQPushConsumer
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/resources/META-INF/eventmesh/org.apache.eventmesh.api.consumer.MeshMQPushConsumer
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+standalone=org.apache.eventmesh.connector.standalone.consumer.StandaloneMeshMQPushConsumerAdaptor

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/resources/META-INF/eventmesh/org.apache.eventmesh.api.producer.MeshMQProducer
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/resources/META-INF/eventmesh/org.apache.eventmesh.api.producer.MeshMQProducer
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+standalone=org.apache.eventmesh.connector.standalone.producer.StandaloneMeshMQProducerAdaptor

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/test/java/org/apache/eventmesh/connector/standalone/broker/StandaloneBrokerTest.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/test/java/org/apache/eventmesh/connector/standalone/broker/StandaloneBrokerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.connector.standalone.broker;
+
+import io.openmessaging.api.Message;
+import org.apache.eventmesh.connector.standalone.broker.model.MessageEntity;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StandaloneBrokerTest {
+
+    @Test
+    public void getInstance() {
+        Assert.assertNotNull(StandaloneBroker.getInstance());
+    }
+
+    @Test
+    public void putMessage() throws InterruptedException {
+        StandaloneBroker instance = StandaloneBroker.getInstance();
+        MessageEntity messageEntity = instance.putMessage("test-topic", new Message());
+        Assert.assertNotNull(messageEntity);
+    }
+
+    @Test
+    public void takeMessage() throws InterruptedException {
+        StandaloneBroker instance = StandaloneBroker.getInstance();
+        instance.putMessage("test-topic", new Message());
+        Message message = instance.takeMessage("test-topic");
+        Assert.assertNotNull(message);
+    }
+
+    @Test
+    public void getMessage() {
+    }
+
+    @Test
+    public void testGetMessage() {
+    }
+
+    @Test
+    public void checkTopicExist() {
+    }
+}

--- a/eventmesh-runtime/build.gradle
+++ b/eventmesh-runtime/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     api 'io.prometheus:simpleclient_httpserver'
 
     implementation project(":eventmesh-connector-plugin:eventmesh-connector-api")
+    implementation project(":eventmesh-connector-plugin:eventmesh-connector-standalone")
     implementation project(":eventmesh-security-plugin:eventmesh-security-api")
     implementation project(":eventmesh-security-plugin:eventmesh-security-acl")
     implementation project(":eventmesh-registry-plugin:eventmesh-registry-api")
@@ -31,6 +32,7 @@ dependencies {
 
 
     testImplementation project(":eventmesh-connector-plugin:eventmesh-connector-api")
+    testImplementation project(":eventmesh-connector-plugin:eventmesh-connector-standalone")
     testImplementation project(":eventmesh-security-plugin:eventmesh-security-api")
     testImplementation project(":eventmesh-security-plugin:eventmesh-security-acl")
     testImplementation project(":eventmesh-registry-plugin:eventmesh-registry-api")

--- a/eventmesh-runtime/conf/eventmesh.properties
+++ b/eventmesh-runtime/conf/eventmesh.properties
@@ -60,7 +60,7 @@ eventMesh.server.gracefulShutdown.sleepIntervalInMills=1000
 eventMesh.server.rebalanceRedirect.sleepIntervalInMills=200
 
 #connector plugin
-eventMesh.connector.plugin.type=rocketmq
+eventMesh.connector.plugin.type=standalone
 
 #security plugin
 eventMesh.server.security.enabled=false


### PR DESCRIPTION
Add standalone connector plugin, close issue #375 

How to use:
1. Config the connector type in eventmesh.properties
```
#connector plugin
eventMesh.connector.plugin.type=standalone
```
2. install the standalone plugin
You can add the dependency in eventmesh-runtime/build.gradle
```
implementation project(":eventmesh-connector-plugin:eventmesh-connector-standalone")
```
Or execute 
```
./gradlew clean jar dist copyConnectorPlugin
```