### PR TITLE
Inefficient Usage of Java Collection

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/IPUtil.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/IPUtil.java
@@ -24,6 +24,7 @@ import java.net.SocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.Enumeration;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -66,8 +67,8 @@ public class IPUtil {
             }
 
             // Traversal Network interface to get the first non-loopback and non-private address
-            ArrayList<String> ipv4Result = new ArrayList<String>();
-            ArrayList<String> ipv6Result = new ArrayList<String>();
+            LinkedList<String> ipv4Result = new LinkedList<String>();
+            LinkedList<String> ipv6Result = new LinkedList<String>();
 
             if (preferNetworkInterface != null) {
                 final Enumeration<InetAddress> en = preferNetworkInterface.getInetAddresses();
@@ -91,9 +92,9 @@ public class IPUtil {
                     return ip;
                 }
 
-                return ipv4Result.get(ipv4Result.size() - 1);
+                return ipv4Result.getLast();
             } else if (!ipv6Result.isEmpty()) {
-                return ipv6Result.get(0);
+                return ipv6Result.getFirst();
             }
             //If failed to find,fall back to localhost
             final InetAddress localHost = InetAddress.getLocalHost();
@@ -134,7 +135,7 @@ public class IPUtil {
         return m.matches();
     }
 
-    private static void getIpResult(ArrayList<String> ipv4Result, ArrayList<String> ipv6Result,
+    private static void getIpResult(LinkedList<String> ipv4Result, LinkedList<String> ipv6Result,
                                     Enumeration<InetAddress> en) {
         while (en.hasMoreElements()) {
             final InetAddress address = en.nextElement();

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/IPUtil.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/IPUtil.java
@@ -25,6 +25,7 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.LinkedList;
+import java.util.HashSet;
 import java.util.Enumeration;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -44,8 +45,10 @@ public class IPUtil {
         String priority = System.getProperty("networkInterface.priority", "eth0<eth1<bond1");
 
         ArrayList<String> preferList = new ArrayList<String>();
+        HashSet<String> preferSet = new HashSet<String>();
         for (String eth : priority.split("<")) {
             preferList.add(eth);
+            preferSet.add(eth);
         }
         NetworkInterface preferNetworkInterface = null;
 
@@ -53,7 +56,7 @@ public class IPUtil {
             Enumeration<NetworkInterface> enumeration1 = NetworkInterface.getNetworkInterfaces();
             while (enumeration1.hasMoreElements()) {
                 final NetworkInterface networkInterface = enumeration1.nextElement();
-                if (!preferList.contains(networkInterface.getName())) {
+                if (!preferSet.contains(networkInterface.getName())) {
                     continue;
                 } else if (preferNetworkInterface == null) {
                     preferNetworkInterface = networkInterface;

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/tcp/Subscription.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/tcp/Subscription.java
@@ -19,12 +19,12 @@ package org.apache.eventmesh.common.protocol.tcp;
 
 import org.apache.eventmesh.common.protocol.SubscriptionItem;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 public class Subscription {
 
-    private List<SubscriptionItem> topicList = new LinkedList<>();
+    private List<SubscriptionItem> topicList = new ArrayList<>();
 
     public Subscription() {
     }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/RejectAllClientHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/RejectAllClientHandler.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -58,7 +58,7 @@ public class RejectAllClientHandler implements HttpHandler {
         try {
             ClientSessionGroupMapping clientSessionGroupMapping = eventMeshTCPServer.getClientSessionGroupMapping();
             ConcurrentHashMap<InetSocketAddress, Session> sessionMap = clientSessionGroupMapping.getSessionMap();
-            final List<InetSocketAddress> successRemoteAddrs = new ArrayList<>();
+            final List<InetSocketAddress> successRemoteAddrs = new LinkedList<>();
             try {
                 logger.info("rejectAllClient in admin====================");
                 if (!sessionMap.isEmpty()) {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/RejectClientBySubSystemHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/RejectClientBySubSystemHandler.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -82,7 +82,7 @@ public class RejectClientBySubSystemHandler implements HttpHandler {
             logger.info("rejectClientBySubSystem in admin,subsys:{}====================", subSystem);
             ClientSessionGroupMapping clientSessionGroupMapping = eventMeshTCPServer.getClientSessionGroupMapping();
             ConcurrentHashMap<InetSocketAddress, Session> sessionMap = clientSessionGroupMapping.getSessionMap();
-            final List<InetSocketAddress> successRemoteAddrs = new ArrayList<InetSocketAddress>();
+            final List<InetSocketAddress> successRemoteAddrs = new LinkedList<InetSocketAddress>();
             try {
                 if (!sessionMap.isEmpty()) {
                     for (Session session : sessionMap.values()) {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/BatchSendMessageProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/BatchSendMessageProcessor.java
@@ -18,6 +18,7 @@
 package org.apache.eventmesh.runtime.core.protocol.http.processor;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -128,7 +129,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
 
         long batchStartTime = System.currentTimeMillis();
 
-        List<Message> msgList = new ArrayList<>();
+        List<Message> msgList = new LinkedList<>();
         Map<String, List<Message>> topicBatchMessageMappings = new ConcurrentHashMap<String, List<Message>>();
         for (SendMessageBatchRequestBody.BatchMessageEntity msg : sendMessageBatchRequestBody.getContents()) {
             if (StringUtils.isBlank(msg.topic)

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/group/dispatch/FreePriorityDispatchStrategy.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/group/dispatch/FreePriorityDispatchStrategy.java
@@ -17,7 +17,7 @@
 
 package org.apache.eventmesh.runtime.core.protocol.tcp.client.group.dispatch;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -40,8 +40,8 @@ public class FreePriorityDispatchStrategy implements DownstreamDispatchStrategy 
             return null;
         }
 
-        List<Session> filtered = new ArrayList<Session>();
-        List<Session> isolatedSessions = new ArrayList<>();
+        LinkedList<Session> filtered = new LinkedList<Session>();
+        LinkedList<Session> isolatedSessions = new LinkedList<>();
         for (Session session : groupConsumerSessions) {
             if (!session.isAvailable(topic)) {
                 continue;
@@ -65,7 +65,7 @@ public class FreePriorityDispatchStrategy implements DownstreamDispatchStrategy 
         }
 
         Collections.shuffle(filtered);
-        Session session = filtered.get(0);
+        Session session = filtered.getFirst();
         return session;
     }
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/SubscribeTask.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/SubscribeTask.java
@@ -17,7 +17,7 @@
 
 package org.apache.eventmesh.runtime.core.protocol.tcp.client.task;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 import io.netty.channel.ChannelHandlerContext;
@@ -49,9 +49,9 @@ public class SubscribeTask extends AbstractTask {
                 throw new Exception("subscriptionInfo is null");
             }
 
-            List<SubscriptionItem> subscriptionItems = new ArrayList<>();
-            for (int i = 0; i < subscriptionInfo.getTopicList().size(); i++) {
-                SubscriptionItem item = subscriptionInfo.getTopicList().get(i);
+            List<SubscriptionItem> subscriptionItems = new LinkedList<>();
+            
+            for (SubscriptionItem item : subscriptionInfo.getTopicList()) {
                 subscriptionItems.add(item);
             }
             synchronized (session) {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/UnSubscribeTask.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/UnSubscribeTask.java
@@ -17,7 +17,7 @@
 
 package org.apache.eventmesh.runtime.core.protocol.tcp.client.task;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -48,7 +48,7 @@ public class UnSubscribeTask extends AbstractTask {
         Package msg = new Package();
         try {
             synchronized (session) {
-                List<SubscriptionItem> topics = new ArrayList<SubscriptionItem>();
+                List<SubscriptionItem> topics = new LinkedList<SubscriptionItem>();
                 if (MapUtils.isNotEmpty(session.getSessionContext().subscribeTopics)) {
                     for (Map.Entry<String, SubscriptionItem> entry : session.getSessionContext().subscribeTopics.entrySet()) {
                         topics.add(entry.getValue());

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/EventMeshUtil.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/EventMeshUtil.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.Properties;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.TimeZone;
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/EventMeshUtil.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/EventMeshUtil.java
@@ -233,8 +233,11 @@ public class EventMeshUtil {
         String priority = System.getProperty("networkInterface.priority", "bond1<eth1<eth0");
         logger.debug("networkInterface.priority: {}", priority);
         ArrayList<String> preferList = new ArrayList<String>();
+        HashSet<String> preferSet = new HashSet<String>();
+        
         for (String eth : priority.split("<")) {
             preferList.add(eth);
+            preferSet.add(eth);
         }
         NetworkInterface preferNetworkInterface = null;
 
@@ -242,7 +245,7 @@ public class EventMeshUtil {
             Enumeration<NetworkInterface> enumeration1 = NetworkInterface.getNetworkInterfaces();
             while (enumeration1.hasMoreElements()) {
                 final NetworkInterface networkInterface = enumeration1.nextElement();
-                if (!preferList.contains(networkInterface.getName())) {
+                if (!preferSet.contains(networkInterface.getName())) {
                     continue;
                 } else if (preferNetworkInterface == null) {
                     preferNetworkInterface = networkInterface;

--- a/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/http/consumer/LiteConsumer.java
+++ b/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/http/consumer/LiteConsumer.java
@@ -18,6 +18,7 @@
 package org.apache.eventmesh.client.http.consumer;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -176,7 +177,7 @@ public class LiteConsumer extends AbstractLiteClient {
     }
 
     private RequestParam generateHeartBeatRequestParam(List<SubscriptionItem> topics, String url) {
-        List<HeartbeatRequestBody.HeartbeatEntity> heartbeatEntities = new ArrayList<>();
+        List<HeartbeatRequestBody.HeartbeatEntity> heartbeatEntities = new LinkedList<>();
         for (SubscriptionItem item : topics) {
             HeartbeatRequestBody.HeartbeatEntity heartbeatEntity = new HeartbeatRequestBody.HeartbeatEntity();
             heartbeatEntity.topic = item.getTopic();

--- a/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/http/util/HttpLoadBalanceUtils.java
+++ b/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/http/util/HttpLoadBalanceUtils.java
@@ -26,7 +26,7 @@ import org.apache.eventmesh.common.loadbalance.RandomLoadBalanceSelector;
 import org.apache.eventmesh.common.loadbalance.Weight;
 import org.apache.eventmesh.common.loadbalance.WeightRoundRobinLoadBalanceSelector;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -45,7 +45,7 @@ public class HttpLoadBalanceUtils {
         LoadBalanceSelector<String> eventMeshServerSelector = null;
         switch (liteClientConfig.getLoadBalanceType()) {
             case RANDOM:
-                List<String> eventMeshAddrList = new ArrayList<>();
+                List<String> eventMeshAddrList = new LinkedList<>();
                 for (String eventMeshAddr : eventMeshAddrs) {
                     if (!IP_PORT_PATTERN.matcher(eventMeshAddr).matches()) {
                         throw new EventMeshException(
@@ -56,7 +56,7 @@ public class HttpLoadBalanceUtils {
                 eventMeshServerSelector = new RandomLoadBalanceSelector<>(eventMeshAddrList);
                 break;
             case WEIGHT_ROUND_ROBIN:
-                List<Weight<String>> eventMeshAddrWeightList = new ArrayList<>();
+                List<Weight<String>> eventMeshAddrWeightList = new LinkedList<>();
                 for (String eventMeshAddrWight : eventMeshAddrs) {
                     if (!IP_PORT_WEIGHT_PATTERN.matcher(eventMeshAddrWight).matches()) {
                         throw new EventMeshException(

--- a/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/impl/SimpleSubClientImpl.java
+++ b/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/impl/SimpleSubClientImpl.java
@@ -17,7 +17,7 @@
 
 package org.apache.eventmesh.client.tcp.impl;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -50,7 +50,7 @@ public class SimpleSubClientImpl extends TcpClient implements SimpleSubClient {
 
     private ReceiveMsgHook callback;
 
-    private List<SubscriptionItem> subscriptionItems = new ArrayList<SubscriptionItem>();
+    private List<SubscriptionItem> subscriptionItems = new LinkedList<SubscriptionItem>();
 
     private ScheduledFuture<?> task;
 


### PR DESCRIPTION
Hi,

We find that there are several inefficient usages of Java Collections:

1. The contains method is invoked upon a list object in a loop. We recommend replacing it with a HashSet.
Random access can occur at several linkedlist objects, which run in linear time complexity. We recommend replacing them with Arraylist objects.
2. ArrayList is inserted before an iteration, while multiple memory reallocation might occur when the size of the list exceeds its capacity. We recommend replacing it with a LinkedList.
3. LinkedList is not inefficient when we perform random access upon it. We recommend replacing it with an ArrayList.

We discovered the above inefficient usage of containers by our tool Ditto. The patch is submitted. Could you please check and accept it? We have tested the patch on our PC. The patched program works well.

Bests

Ditto