### PR TITLE
[ISSUE #541] rename issue

### DIFF
--- a/eventmesh-schema-registry/eventmesh-schema-registry-server/src/main/java/org/apache/eventmesh/schema/registry/server/exception/OpenSchemaExceptionHandler.java
+++ b/eventmesh-schema-registry/eventmesh-schema-registry-server/src/main/java/org/apache/eventmesh/schema/registry/server/exception/OpenSchemaExceptionHandler.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 public class OpenSchemaExceptionHandler {
 
     @ExceptionHandler(value = OpenSchemaException.class)
-    public ResponseEntity<ErrorResponse> ExceptionHandler(OpenSchemaException e){
+    public ResponseEntity<ErrorResponse> exceptionHandler(OpenSchemaException e){
         return ResponseEntity.status(e.getErr_status().value()).body(new ErrorResponse(e.getErr_code(), e.getErr_message()));
     }
 }

--- a/eventmesh-schema-registry/eventmesh-schema-registry-server/src/main/java/org/apache/eventmesh/schema/registry/server/service/SubjectService.java
+++ b/eventmesh-schema-registry/eventmesh-schema-registry-server/src/main/java/org/apache/eventmesh/schema/registry/server/service/SubjectService.java
@@ -16,7 +16,7 @@
  */
 package org.apache.eventmesh.schema.registry.server.service;
 
-import org.apache.eventmesh.openschemaregistry.domain.*;
+import org.apache.eventmesh.schema.registry.server.domain.*;
 import org.apache.eventmesh.schema.registry.server.exception.ExceptionEnum;
 import org.apache.eventmesh.schema.registry.server.exception.OpenSchemaException;
 import org.apache.eventmesh.schema.registry.server.repository.SchemaRepository;


### PR DESCRIPTION
rename ```import org.apache.eventmesh.openschemaregistry.domain.*;``` to ```org.apache.eventmesh.schema.registry.server.domain.*;```

Fixes ISSUE #541.

### Motivation
Seems that part of the package name of schema registry is renamed from openschemaregistry to schema.registry.server, but one of the packages imported in SubjectService.java is not changed.

### Modifications
change import org.apache.eventmesh.openschemaregistry.domain.*; to import org.apache.eventmesh.schema.registry.server.domain.*;

