### PR TITLE
[ISSUE #536] fix OpenSchemaRegistryApplication start error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -377,8 +377,6 @@ subprojects {
             dependency "com.h3xstream.findsecbugs:findsecbugs-plugin:1.11.0"
             dependency "com.mebigfatguy.fb-contrib:fb-contrib:7.4.7"
 
-            dependency "org.springframework.boot:spring-boot-starter-web:2.1.6.RELEASE"
-
             dependency "junit:junit:4.12"
             dependency "com.github.stefanbirkner:system-rules:1.16.1"
             dependency "org.assertj:assertj-core:2.6.0"
@@ -387,11 +385,11 @@ subprojects {
             dependency "org.powermock:powermock-module-junit4:2.0.2"
             dependency "org.powermock:powermock-api-mockito2:2.0.2"
 
-
+            dependency "org.springframework.boot:spring-boot-starter-web:2.5.4"
             dependency 'org.springframework.boot:spring-boot-starter-data-jdbc:2.5.4'
             dependency 'org.springframework.boot:spring-boot-starter-data-jpa:2.5.4'
             dependency 'org.springframework.boot:spring-boot-starter-jdbc:2.5.4'
-            dependency 'org.springframework:spring-beans:5.1.8.RELEASE'
+            dependency 'org.springframework:spring-beans:5.3.10'
             dependency 'org.projectlombok:lombok:1.18.20'
             dependency 'com.h2database:h2:1.4.200'
             dependency "io.cloudevents:cloudevents-core:2.2.0"

--- a/eventmesh-schema-registry/eventmesh-schema-registry-server/src/main/resources/application.yml
+++ b/eventmesh-schema-registry/eventmesh-schema-registry-server/src/main/resources/application.yml
@@ -22,7 +22,7 @@ spring:
       enabled: true
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:./eventmesh-openschema/eventmesh-openschema-registry/src/main/resources/h2/db
+    url: jdbc:h2:./eventmesh-schema-registry/eventmesh-schema-registry-server/src/main/resources/h2/db
     username: root
     password: test
   jpa:


### PR DESCRIPTION
Fixes ISSUE #536 .

### Motivation

*Explain the content here.*
1. fix OpenSchemaRegistryApplication start error
2. change h2-db path in ```application.yml```

*Explain why you want to make the changes and what problem you're trying to solve.*
1. Spring version conflict makes OpenSchemaRegistryApplication start error. The way to solve it is by updating all spring-related dependencies to the latest.
2. Change h2-db path so that ```.db``` is created under ```eventmesh-schema-registry-server/resources```.


### Modifications
1. update dependencies version
2. change h2-db path



### Documentation

- Does this pull request introduce a new feature? no, it solves a bug
