### PR TITLE
[ISSUE #580] Add checkstyle gradle plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,8 @@ jobs:
           java-version: ${{ matrix.java }}
 
       - name: Build
-        run: ./gradlew clean build jacocoTestReport checkLicense
+        # skip check here, since we use Checkstyle task to check the added file
+        run: ./gradlew clean build jacocoTestReport checkLicense -x check
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,8 @@ Editor -> Code Style -> Java -> Scheme -> Import Scheme -> CheckStyle Configurat
 ```
 If you can't see CheckStyle Configuration section under Import Scheme, you can install CheckStyle-IDEA plugin first, and you will see it.
 
+You can also use `./gradlew check` to check the code style.
+(NOTE: this command will check all file in project, when you submit a pr, the ci will only check the file has been changed in this pr).
 ## Contributing
 
 We are always very happy to have contributions, whether for typo fix, bug fix or big new features. Please do not ever

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -16,6 +16,7 @@ Editor -> Code Style -> Java -> Scheme -> Import Scheme -> CheckStyle Configurat
 ```
 如果你在Import Scheme下看不到CheckStyle Configuration选项，你可以先安装CheckStyle-IDEA插件，然后你就可以看到这个选项了。
 
+你也可以通过执行`./gradlew check`来检查代码格式。(NOTE: 这个命令将会检查整个项目中的代码格式， 当你提交一个PR时，CI只会检查在此次PR中被被修改的文件的代码格式)
 ## 贡献
 
 无论是对于拼写错误，BUG修复还是重要的新功能，我们总是很乐意接受您的贡献。请不要犹豫，在Github Issue上提出或者通过邮件列表进行讨论。

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ allprojects {
     apply plugin: "pmd"
     apply plugin: "java-library"
     apply plugin: 'signing'
+    apply plugin: 'checkstyle'
     apply plugin: 'com.github.jk1.dependency-license-report'
 
     [compileJava, compileTestJava, javadoc]*.options*.encoding = 'UTF-8'
@@ -78,6 +79,14 @@ allprojects {
         writer.flush()
         writer.close()
     }
+
+    checkstyle {
+        toolVersion = '9.0'
+        ignoreFailures = false
+        showViolations = true
+        maxWarnings = 0
+        configFile = new File("${rootDir}/style/checkStyle.xml")
+    }
 }
 
 task tar(type: Tar) {
@@ -103,38 +112,42 @@ task installPlugin() {
     if (!new File("${rootDir}/dist").exists()) {
         return
     }
-    // pluginType -> [pluginInstanceName -> moduleName]
-    Map<String, Map<String, String>> pluginTypeMap = [
-            "connector": ["rocketmq": "eventmesh-connector-rocketmq", "standalone": "eventmesh-connector-standalone",],
-            "security" : ["acl": "eventmesh-security-acl",],
-            "registry" : ["namesrv": "eventmesh-registry-namesrv",]
-    ]
     String[] libJars = java.util.Optional.ofNullable(new File("${rootDir}/dist/lib").list()).orElseGet(() -> new String[0])
     getAllprojects().forEach(subProject -> {
-        pluginTypeMap.forEach((pluginType, pluginInstanceMap) -> {
-            pluginInstanceMap.forEach((pluginInstanceName, moduleName) -> {
-                if (moduleName == subProject.name) {
-                    println String.format("install plugin, pluginType: %s, pluginInstanceName: %s, module: %s",
-                            pluginType, pluginInstanceName, moduleName)
+        var file = new File("${subProject.projectDir}/gradle.properties")
+        if (!file.exists()) {
+            return
+        }
+        var properties = new Properties()
+        properties.load(new FileInputStream(file))
+        var pluginType = properties.getProperty("pluginType")
+        var pluginName = properties.getProperty("pluginName")
+        if (pluginType == null || pluginName == null) {
+            return
+        }
+        var pluginFile = new File("${rootDir}/dist/plugin/${pluginType}/${pluginName}")
+        if (pluginFile.exists()) {
+            return
+        }
+        pluginFile.mkdirs()
+        println String.format(
+                "install plugin, pluginType: %s, pluginInstanceName: %s, module: %s", pluginType, pluginName, subProject.getName()
+        )
 
-                    new File("${rootDir}/dist/plugin/${pluginType}/${pluginInstanceName}").mkdirs()
-                    copy {
-                        into "${rootDir}/dist/plugin/${pluginType}/${pluginInstanceName}"
-                        from "${subProject.getProjectDir()}/dist/apps"
-                    }
-                    copy {
-                        into "${rootDir}/dist/plugin/${pluginType}/${pluginInstanceName}"
-                        from "${subProject.getProjectDir()}/dist/lib/"
-                        exclude(libJars)
-                    }
-                    copy {
-                        into "${rootDir}/dist/conf"
-                        from "${subProject.getProjectDir()}/dist/conf"
-                        exclude 'META-INF'
-                    }
-                }
-            })
-        })
+        copy {
+            into "${rootDir}/dist/plugin/${pluginType}/${pluginName}"
+            from "${subProject.getProjectDir()}/dist/apps"
+        }
+        copy {
+            into "${rootDir}/dist/plugin/${pluginType}/${pluginName}"
+            from "${subProject.getProjectDir()}/dist/lib/"
+            exclude(libJars)
+        }
+        copy {
+            into "${rootDir}/dist/conf"
+            from "${subProject.getProjectDir()}/dist/conf"
+            exclude 'META-INF'
+        }
     })
 }
 

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/gradle.properties
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/gradle.properties
@@ -13,3 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+pluginType=connector
+pluginName=standalone

--- a/eventmesh-protocol-plugin/eventmesh-protocol-cloudevents/gradle.properties
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-cloudevents/gradle.properties
@@ -14,7 +14,5 @@
 # limitations under the License.
 #
 
-rocketmq_version=4.7.1
-
-pluginType=connector
-pluginName=rocketmq
+pluginType=protocol
+pluginName=cloudevents

--- a/eventmesh-protocol-plugin/eventmesh-protocol-openmessage/gradle.properties
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-openmessage/gradle.properties
@@ -14,7 +14,5 @@
 # limitations under the License.
 #
 
-rocketmq_version=4.7.1
-
-pluginType=connector
-pluginName=rocketmq
+pluginType=protocol
+pluginName=openmessage

--- a/eventmesh-registry-plugin/eventmesh-registry-namesrv/gradle.properties
+++ b/eventmesh-registry-plugin/eventmesh-registry-namesrv/gradle.properties
@@ -14,7 +14,5 @@
 # limitations under the License.
 #
 
-rocketmq_version=4.7.1
-
-pluginType=connector
-pluginName=rocketmq
+pluginType=registry
+pluginName=namesrv

--- a/eventmesh-security-plugin/eventmesh-security-acl/gradle.properties
+++ b/eventmesh-security-plugin/eventmesh-security-acl/gradle.properties
@@ -14,7 +14,5 @@
 # limitations under the License.
 #
 
-rocketmq_version=4.7.1
-
-pluginType=connector
-pluginName=rocketmq
+pluginType=security
+pluginName=acl


### PR DESCRIPTION
The check style will not be trigger in build, you need to manually execute `./gradlew check`.

And this pr also change the plugin package code, when add a new plugin, need to add a gradle.properties file, and defined the plugin name.
close #580 