### PR TITLE
[MINOR] Upgrade log4j to 2.15.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -407,9 +407,9 @@ subprojects {
             dependency "com.google.guava:guava:29.0-jre"
             
             dependency "org.slf4j:slf4j-api:1.7.30"
-            dependency "org.apache.logging.log4j:log4j-api:2.13.3"
-            dependency "org.apache.logging.log4j:log4j-core:2.13.3"
-            dependency "org.apache.logging.log4j:log4j-slf4j-impl:2.13.3"
+            dependency "org.apache.logging.log4j:log4j-api:2.15.0"
+            dependency "org.apache.logging.log4j:log4j-core:2.15.0"
+            dependency "org.apache.logging.log4j:log4j-slf4j-impl:2.15.0"
 
             dependency "com.lmax:disruptor:3.4.2"
 

--- a/eventmesh-connector-plugin/eventmesh-connector-rocketmq/build.gradle
+++ b/eventmesh-connector-plugin/eventmesh-connector-rocketmq/build.gradle
@@ -17,6 +17,7 @@
 
 configurations {
     implementation.exclude group: 'ch.qos.logback', module: 'logback-classic'
+    implementation.exclude group: 'log4j', module: 'log4j'
 }
 
 List rocketmq = [

--- a/tools/third-party-dependencies/known-dependencies.txt
+++ b/tools/third-party-dependencies/known-dependencies.txt
@@ -32,7 +32,6 @@ jna-4.2.2.jar
 jsr305-3.0.2.jar
 junit-4.12.jar
 listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
-log4j-1.2.17.jar
 log4j-api-2.15.0.jar
 log4j-core-2.15.0.jar
 log4j-slf4j-impl-2.15.0.jar

--- a/tools/third-party-dependencies/known-dependencies.txt
+++ b/tools/third-party-dependencies/known-dependencies.txt
@@ -33,9 +33,9 @@ jsr305-3.0.2.jar
 junit-4.12.jar
 listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
 log4j-1.2.17.jar
-log4j-api-2.13.3.jar
-log4j-core-2.13.3.jar
-log4j-slf4j-impl-2.13.3.jar
+log4j-api-2.15.0.jar
+log4j-core-2.15.0.jar
+log4j-slf4j-impl-2.15.0.jar
 logback-core-1.0.13.jar
 metrics-annotation-4.1.0.jar
 metrics-core-4.1.0.jar


### PR DESCRIPTION
Since log4j2 has released 2.15.0, it's time to upgrade this version before EventMesh 1.3.0 release.