### PR TITLE
[ISSUE #726] Remove the misleading annotation

### DIFF
--- a/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/impl/cloudevent/CloudEventTCPPubClient.java
+++ b/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/impl/cloudevent/CloudEventTCPPubClient.java
@@ -96,7 +96,6 @@ class CloudEventTCPPubClient extends TcpClient implements EventMeshTCPPubClient<
             super.send(msg);
             this.callbackConcurrentHashMap.put((String) RequestContext.key(msg), callback);
         } catch (Exception ex) {
-            // should trigger callback?
             throw new EventMeshException("asyncRR error", ex);
         }
     }


### PR DESCRIPTION
Fix #726 

### Motivation
If we throw an exception, then we don't need to trigger the callback anymore.

### Modifications
Remove the annotation
