### PR TITLE
[ISSUE #742] add eventmesh-admin-rocketmq into rootProject

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -247,6 +247,7 @@ subprojects {
             new File("${projectDir}/dist/licenses").mkdirs()
         }
         Set<String> rootProject = ["eventmesh-admin",
+                                   "eventmesh-admin-rocketmq",
                                    "eventmesh-common",
                                    "eventmesh-connector-api",
                                    "eventmesh-metrics-api",


### PR DESCRIPTION
Fixes ISSUE #742 .

### Modifications
add "eventmesh-admin-rocketmq" into rootProject, so eventmesh-admin-rocketmq-xxx.jar will be added into apps folder.
