### PR TITLE
[MINOR] Allow run script in other directory

### DIFF
--- a/eventmesh-runtime/bin/start.sh
+++ b/eventmesh-runtime/bin/start.sh
@@ -88,7 +88,7 @@ fi
 
 echo "eventmesh use java location= "$JAVA
 
-EVENTMESH_HOME=`cd "./.." && pwd`
+EVENTMESH_HOME=`cd $(dirname $0)/.. && pwd`
 
 export EVENTMESH_HOME
 

--- a/eventmesh-runtime/bin/stop.sh
+++ b/eventmesh-runtime/bin/stop.sh
@@ -20,7 +20,7 @@
 #detect operating system.
 OS=$(uname -o)
 
-EVENTMESH_HOME=`cd "./.." && pwd`
+EVENTMESH_HOME=`cd $(dirname $0)/.. && pwd`
 
 export EVENTMESH_HOME
 


### PR DESCRIPTION
### Motivation

Allow run script in other directory.
Currently, it must be run in the bin directory

### Modifications

use `dirname` instead

