### PR TITLE
[Issue #768] fix issue in update HTTP subscriber

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/SubscriptionItem.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/SubscriptionItem.java
@@ -17,7 +17,11 @@
 
 package org.apache.eventmesh.common.protocol;
 
-public class SubscriptionItem implements Cloneable {
+import com.google.common.base.Objects;
+
+import java.io.Serializable;
+
+public class SubscriptionItem implements Serializable {
 
     private String topic;
 
@@ -68,8 +72,20 @@ public class SubscriptionItem implements Cloneable {
     }
 
     @Override
-    public SubscriptionItem clone() {
-        return new SubscriptionItem(topic, mode, type);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SubscriptionItem that = (SubscriptionItem) o;
+        return Objects.equal(topic, that.topic) && mode == that.mode && type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(topic, mode, type);
     }
 }
 

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/SubscriptionItem.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/SubscriptionItem.java
@@ -17,7 +17,7 @@
 
 package org.apache.eventmesh.common.protocol;
 
-public class SubscriptionItem {
+public class SubscriptionItem implements Cloneable {
 
     private String topic;
 
@@ -65,6 +65,11 @@ public class SubscriptionItem {
                 + ", mode=" + mode
                 + ", type=" + type
                 + '}';
+    }
+
+    @Override
+    public SubscriptionItem clone() {
+        return new SubscriptionItem(topic, mode, type);
     }
 }
 

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/SubscriptionItem.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/SubscriptionItem.java
@@ -17,9 +17,9 @@
 
 package org.apache.eventmesh.common.protocol;
 
-import com.google.common.base.Objects;
-
 import java.io.Serializable;
+
+import com.google.common.base.Objects;
 
 public class SubscriptionItem implements Serializable {
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/consumergroup/ConsumerGroupConf.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/consumergroup/ConsumerGroupConf.java
@@ -17,13 +17,13 @@
 
 package org.apache.eventmesh.runtime.core.consumergroup;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 
 import com.google.common.collect.Maps;
 
-public class ConsumerGroupConf implements Cloneable {
+public class ConsumerGroupConf implements Serializable {
     //eg . 5013-1A0
     private String consumerGroup;
 
@@ -76,16 +76,5 @@ public class ConsumerGroupConf implements Cloneable {
                 .append("groupName=").append(consumerGroup).append(",")
                 .append(",consumerGroupTopicConf=").append(consumerGroupTopicConf).append("}");
         return sb.toString();
-    }
-
-    @Override
-    public ConsumerGroupConf clone() {
-        ConsumerGroupConf clone = new ConsumerGroupConf(consumerGroup);
-
-        Map<String, ConsumerGroupTopicConf> cloneGroupTopicConf = new ConcurrentHashMap<>();
-        consumerGroupTopicConf.forEach((topic, groupTopicConf) -> cloneGroupTopicConf.put(topic, groupTopicConf.clone()));
-
-        clone.setConsumerGroupTopicConf(cloneGroupTopicConf);
-        return clone;
     }
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/consumergroup/ConsumerGroupConf.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/consumergroup/ConsumerGroupConf.java
@@ -19,10 +19,11 @@ package org.apache.eventmesh.runtime.core.consumergroup;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.google.common.collect.Maps;
 
-public class ConsumerGroupConf {
+public class ConsumerGroupConf implements Cloneable {
     //eg . 5013-1A0
     private String consumerGroup;
 
@@ -75,5 +76,16 @@ public class ConsumerGroupConf {
                 .append("groupName=").append(consumerGroup).append(",")
                 .append(",consumerGroupTopicConf=").append(consumerGroupTopicConf).append("}");
         return sb.toString();
+    }
+
+    @Override
+    public ConsumerGroupConf clone() {
+        ConsumerGroupConf clone = new ConsumerGroupConf(consumerGroup);
+
+        Map<String, ConsumerGroupTopicConf> cloneGroupTopicConf = new ConcurrentHashMap<>();
+        consumerGroupTopicConf.forEach((topic, groupTopicConf) -> cloneGroupTopicConf.put(topic, groupTopicConf.clone()));
+
+        clone.setConsumerGroupTopicConf(cloneGroupTopicConf);
+        return clone;
     }
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/consumergroup/ConsumerGroupTopicConf.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/consumergroup/ConsumerGroupTopicConf.java
@@ -19,6 +19,7 @@ package org.apache.eventmesh.runtime.core.consumergroup;
 
 import org.apache.eventmesh.common.protocol.SubscriptionItem;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -30,7 +31,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
-public class ConsumerGroupTopicConf {
+public class ConsumerGroupTopicConf implements Cloneable {
 
     public static Logger logger = LoggerFactory.getLogger(ConsumerGroupTopicConf.class);
 
@@ -125,5 +126,20 @@ public class ConsumerGroupTopicConf {
 
     public void setUrls(Set<String> urls) {
         this.urls = urls;
+    }
+
+    @Override
+    public ConsumerGroupTopicConf clone() {
+        ConsumerGroupTopicConf clone = new ConsumerGroupTopicConf();
+        clone.setConsumerGroup(consumerGroup);
+        clone.setTopic(topic);
+        clone.setSubscriptionItem(subscriptionItem.clone());
+
+        Map<String, List<String>> cloneIdcUrls = Maps.newConcurrentMap();
+        idcUrls.forEach((idc, urls) -> cloneIdcUrls.put(idc, new ArrayList<>(urls)));
+        clone.setIdcUrls(cloneIdcUrls);
+
+        clone.setUrls(Sets.newConcurrentHashSet(urls));
+        return clone;
     }
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/consumergroup/ConsumerGroupTopicConf.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/consumergroup/ConsumerGroupTopicConf.java
@@ -19,7 +19,7 @@ package org.apache.eventmesh.runtime.core.consumergroup;
 
 import org.apache.eventmesh.common.protocol.SubscriptionItem;
 
-import java.util.ArrayList;
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
-public class ConsumerGroupTopicConf implements Cloneable {
+public class ConsumerGroupTopicConf implements Serializable {
 
     public static Logger logger = LoggerFactory.getLogger(ConsumerGroupTopicConf.class);
 
@@ -126,20 +126,5 @@ public class ConsumerGroupTopicConf implements Cloneable {
 
     public void setUrls(Set<String> urls) {
         this.urls = urls;
-    }
-
-    @Override
-    public ConsumerGroupTopicConf clone() {
-        ConsumerGroupTopicConf clone = new ConsumerGroupTopicConf();
-        clone.setConsumerGroup(consumerGroup);
-        clone.setTopic(topic);
-        clone.setSubscriptionItem(subscriptionItem.clone());
-
-        Map<String, List<String>> cloneIdcUrls = Maps.newConcurrentMap();
-        idcUrls.forEach((idc, urls) -> cloneIdcUrls.put(idc, new ArrayList<>(urls)));
-        clone.setIdcUrls(cloneIdcUrls);
-
-        clone.setUrls(Sets.newConcurrentHashSet(urls));
-        return clone;
     }
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/ConsumerManager.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/ConsumerManager.java
@@ -192,7 +192,7 @@ public class ConsumerManager {
             ConsumerGroupStateEvent notification = new ConsumerGroupStateEvent();
             notification.action = ConsumerGroupStateEvent.ConsumerGroupStateAction.NEW;
             notification.consumerGroup = consumerGroup;
-            notification.consumerGroupConfig = latestConsumerGroupConfig;
+            notification.consumerGroupConfig = latestConsumerGroupConfig.clone();
             eventMeshHTTPServer.getEventBus().post(notification);
             return;
         }
@@ -201,7 +201,7 @@ public class ConsumerManager {
             ConsumerGroupStateEvent notification = new ConsumerGroupStateEvent();
             notification.action = ConsumerGroupStateEvent.ConsumerGroupStateAction.CHANGE;
             notification.consumerGroup = consumerGroup;
-            notification.consumerGroupConfig = latestConsumerGroupConfig;
+            notification.consumerGroupConfig = latestConsumerGroupConfig.clone();
             eventMeshHTTPServer.getEventBus().post(notification);
             return;
         }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/ConsumerManager.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/ConsumerManager.java
@@ -24,6 +24,7 @@ import org.apache.eventmesh.runtime.core.consumergroup.ConsumerGroupTopicConf;
 import org.apache.eventmesh.runtime.core.consumergroup.event.ConsumerGroupStateEvent;
 import org.apache.eventmesh.runtime.core.consumergroup.event.ConsumerGroupTopicConfChangeEvent;
 import org.apache.eventmesh.runtime.core.protocol.http.processor.inf.Client;
+import org.apache.eventmesh.runtime.util.EventMeshUtil;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -40,7 +41,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.eventmesh.runtime.util.EventMeshUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/ConsumerManager.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/ConsumerManager.java
@@ -40,6 +40,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.eventmesh.runtime.util.EventMeshUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -192,7 +193,7 @@ public class ConsumerManager {
             ConsumerGroupStateEvent notification = new ConsumerGroupStateEvent();
             notification.action = ConsumerGroupStateEvent.ConsumerGroupStateAction.NEW;
             notification.consumerGroup = consumerGroup;
-            notification.consumerGroupConfig = latestConsumerGroupConfig.clone();
+            notification.consumerGroupConfig = EventMeshUtil.cloneObject(latestConsumerGroupConfig);
             eventMeshHTTPServer.getEventBus().post(notification);
             return;
         }
@@ -201,7 +202,7 @@ public class ConsumerManager {
             ConsumerGroupStateEvent notification = new ConsumerGroupStateEvent();
             notification.action = ConsumerGroupStateEvent.ConsumerGroupStateAction.CHANGE;
             notification.consumerGroup = consumerGroup;
-            notification.consumerGroupConfig = latestConsumerGroupConfig.clone();
+            notification.consumerGroupConfig = EventMeshUtil.cloneObject(latestConsumerGroupConfig);
             eventMeshHTTPServer.getEventBus().post(notification);
             return;
         }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/EventMeshUtil.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/EventMeshUtil.java
@@ -26,6 +26,11 @@ import org.apache.eventmesh.runtime.constants.EventMeshVersion;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
@@ -343,5 +348,23 @@ public class EventMeshUtil {
                 .getThreadNamePrefix(), scheduledExecutorService.getQueue().size(), scheduledExecutorService
                 .getPoolSize(), scheduledExecutorService.getActiveCount(), scheduledExecutorService
                 .getCompletedTaskCount());
+    }
+
+    /**
+     * Perform deep clone of the given object using serialization
+     * @param object
+     * @param <T>
+     * @return
+     * @throws IOException
+     * @throws ClassNotFoundException
+     */
+    public static <T> T cloneObject(T object) throws IOException, ClassNotFoundException {
+        ByteArrayOutputStream byOut = new ByteArrayOutputStream();
+        ObjectOutputStream outputStream = new ObjectOutputStream(byOut);
+        outputStream.writeObject(object);
+
+        ByteArrayInputStream byIn = new ByteArrayInputStream(byOut.toByteArray());
+        ObjectInputStream inputStream = new ObjectInputStream(byIn);
+        return (T) inputStream.readObject();
     }
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/EventMeshUtil.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/EventMeshUtil.java
@@ -353,8 +353,7 @@ public class EventMeshUtil {
     /**
      * Perform deep clone of the given object using serialization
      * @param object
-     * @param <T>
-     * @return
+     * @return cloned object
      * @throws IOException
      * @throws ClassNotFoundException
      */


### PR DESCRIPTION
<!--

Fixes ISSUE #768

### Motivation

This is to fix the bug of updating HTTP subscriber, and it is not taking effect.


### Modifications

update `ConsumerManager` notification method to use object.clone() instead of the same object reference.



