### PR TITLE
[ISSUE #839] Replaced "eventmeshmessage" with defined constant

### DIFF
--- a/eventmesh-protocol-plugin/eventmesh-protocol-meshmessage/src/main/java/org/apache/eventmesh/protocol/meshmessage/resolver/grpc/GrpcMessageProtocolResolver.java
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-meshmessage/src/main/java/org/apache/eventmesh/protocol/meshmessage/resolver/grpc/GrpcMessageProtocolResolver.java
@@ -24,6 +24,7 @@ import org.apache.eventmesh.common.protocol.grpc.protos.BatchMessage.MessageItem
 import org.apache.eventmesh.common.protocol.grpc.protos.RequestHeader;
 import org.apache.eventmesh.common.protocol.grpc.protos.SimpleMessage;
 import org.apache.eventmesh.protocol.api.exception.ProtocolHandleException;
+import org.apache.eventmesh.protocol.meshmessage.MeshMessageProtocolConstant;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -65,7 +66,7 @@ public class GrpcMessageProtocolResolver {
 
                 cloudEventBuilder = cloudEventBuilder.withId(message.getSeqNum())
                     .withSubject(message.getTopic())
-                    .withType("eventmeshmessage")
+                    .withType(MeshMessageProtocolConstant.PROTOCOL_NAME)
                     .withSource(URI.create("/"))
                     .withData(content.getBytes(StandardCharsets.UTF_8))
                     .withExtension(ProtocolKey.ENV, env)
@@ -95,7 +96,7 @@ public class GrpcMessageProtocolResolver {
                 cloudEventBuilder = CloudEventBuilder.v03();
                 cloudEventBuilder = cloudEventBuilder.withId(message.getSeqNum())
                     .withSubject(message.getTopic())
-                    .withType("eventmeshmessage")
+                    .withType(MeshMessageProtocolConstant.PROTOCOL_NAME)
                     .withSource(URI.create("/"))
                     .withData(content.getBytes(StandardCharsets.UTF_8))
                     .withExtension(ProtocolKey.ENV, env)
@@ -156,7 +157,7 @@ public class GrpcMessageProtocolResolver {
 
                 cloudEventBuilder = cloudEventBuilder.withId(item.getSeqNum())
                     .withSubject(message.getTopic())
-                    .withType("eventmeshmessage")
+                    .withType(MeshMessageProtocolConstant.PROTOCOL_NAME)
                     .withSource(URI.create("/"))
                     .withData(content.getBytes(StandardCharsets.UTF_8))
                     .withExtension(ProtocolKey.ENV, env)
@@ -186,7 +187,7 @@ public class GrpcMessageProtocolResolver {
                 cloudEventBuilder = CloudEventBuilder.v03();
                 cloudEventBuilder = cloudEventBuilder.withId(item.getSeqNum())
                     .withSubject(message.getTopic())
-                    .withType("eventmeshmessage")
+                    .withType(MeshMessageProtocolConstant.PROTOCOL_NAME)
                     .withSource(URI.create("/"))
                     .withData(content.getBytes(StandardCharsets.UTF_8))
                     .withExtension(ProtocolKey.ENV, env)

--- a/eventmesh-protocol-plugin/eventmesh-protocol-meshmessage/src/main/java/org/apache/eventmesh/protocol/meshmessage/resolver/http/SendMessageBatchV2ProtocolResolver.java
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-meshmessage/src/main/java/org/apache/eventmesh/protocol/meshmessage/resolver/http/SendMessageBatchV2ProtocolResolver.java
@@ -25,6 +25,7 @@ import org.apache.eventmesh.common.protocol.http.common.ProtocolVersion;
 import org.apache.eventmesh.common.protocol.http.header.Header;
 import org.apache.eventmesh.common.protocol.http.header.message.SendMessageBatchV2RequestHeader;
 import org.apache.eventmesh.protocol.api.exception.ProtocolHandleException;
+import org.apache.eventmesh.protocol.meshmessage.MeshMessageProtocolConstant;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -65,7 +66,7 @@ public class SendMessageBatchV2ProtocolResolver {
 
                 cloudEventBuilder = cloudEventBuilder.withId(sendMessageBatchV2RequestBody.getBizSeqNo())
                         .withSubject(sendMessageBatchV2RequestBody.getTopic())
-                        .withType("eventmeshmessage")
+                        .withType(MeshMessageProtocolConstant.PROTOCOL_NAME)
                         .withSource(URI.create("/"))
                         .withData(content.getBytes(StandardCharsets.UTF_8))
                         .withExtension(ProtocolKey.REQUEST_CODE, code)
@@ -92,7 +93,7 @@ public class SendMessageBatchV2ProtocolResolver {
                 cloudEventBuilder = CloudEventBuilder.v03();
                 cloudEventBuilder = cloudEventBuilder.withId(sendMessageBatchV2RequestBody.getBizSeqNo())
                         .withSubject(sendMessageBatchV2RequestBody.getTopic())
-                        .withType("eventmeshmessage")
+                        .withType(MeshMessageProtocolConstant.PROTOCOL_NAME)
                         .withSource(URI.create("/"))
                         .withData(content.getBytes(StandardCharsets.UTF_8))
                         .withExtension(ProtocolKey.REQUEST_CODE, code)

--- a/eventmesh-protocol-plugin/eventmesh-protocol-meshmessage/src/main/java/org/apache/eventmesh/protocol/meshmessage/resolver/http/SendMessageRequestProtocolResolver.java
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-meshmessage/src/main/java/org/apache/eventmesh/protocol/meshmessage/resolver/http/SendMessageRequestProtocolResolver.java
@@ -24,6 +24,7 @@ import org.apache.eventmesh.common.protocol.http.common.ProtocolVersion;
 import org.apache.eventmesh.common.protocol.http.header.Header;
 import org.apache.eventmesh.common.protocol.http.header.message.SendMessageRequestHeader;
 import org.apache.eventmesh.protocol.api.exception.ProtocolHandleException;
+import org.apache.eventmesh.protocol.meshmessage.MeshMessageProtocolConstant;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -65,7 +66,7 @@ public class SendMessageRequestProtocolResolver {
 
                 cloudEventBuilder = cloudEventBuilder.withId(sendMessageRequestBody.getBizSeqNo())
                         .withSubject(sendMessageRequestBody.getTopic())
-                        .withType("eventmeshmessage")
+                        .withType(MeshMessageProtocolConstant.PROTOCOL_NAME)
                         .withSource(URI.create("/"))
                         .withData(content.getBytes(StandardCharsets.UTF_8))
                         .withExtension(ProtocolKey.REQUEST_CODE, code)
@@ -94,7 +95,7 @@ public class SendMessageRequestProtocolResolver {
                 cloudEventBuilder = CloudEventBuilder.v03();
                 cloudEventBuilder = cloudEventBuilder.withId(sendMessageRequestBody.getBizSeqNo())
                         .withSubject(sendMessageRequestBody.getTopic())
-                        .withType("eventmeshmessage")
+                        .withType(MeshMessageProtocolConstant.PROTOCOL_NAME)
                         .withSource(URI.create("/"))
                         .withData(content.getBytes(StandardCharsets.UTF_8))
                         .withExtension(ProtocolKey.REQUEST_CODE, code)

--- a/eventmesh-protocol-plugin/eventmesh-protocol-meshmessage/src/main/java/org/apache/eventmesh/protocol/meshmessage/resolver/tcp/TcpMessageProtocolResolver.java
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-meshmessage/src/main/java/org/apache/eventmesh/protocol/meshmessage/resolver/tcp/TcpMessageProtocolResolver.java
@@ -74,7 +74,7 @@ public class TcpMessageProtocolResolver {
         cloudEventBuilder = cloudEventBuilder
                 .withId(header.getSeq())
                 .withSource(URI.create("/"))
-                .withType("eventmeshmessage")
+                .withType(MeshMessageProtocolConstant.PROTOCOL_NAME)
                 .withSubject(topic)
                 .withData(content.getBytes(StandardCharsets.UTF_8));
 


### PR DESCRIPTION
Fixes ISSUE #<839>.
### Motivation

First time contributor working on a starter issue.
### Modifications

Replaced "eventmeshmessage" with "MeshMesssageProtocolConstant.PROTOCOL_NAME" across the following files: GrpcMessageProtocolResolver, SendMessageRequestProtocolResolver, SendMessageBatchV2ProtocolResolver, and TcpMessageProtocolResolver.