### PR TITLE
[ISSUE-856] Add test code for module [eventmesh-trace-plugin]

### DIFF
--- a/eventmesh-trace-plugin/eventmesh-trace-api/build.gradle
+++ b/eventmesh-trace-plugin/eventmesh-trace-api/build.gradle
@@ -27,4 +27,5 @@ dependencies {
 
     testCompileOnly 'org.projectlombok:lombok:1.18.22'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.22'
+    testImplementation project(":eventmesh-trace-plugin:eventmesh-trace-zipkin")
 }

--- a/eventmesh-trace-plugin/eventmesh-trace-api/src/test/java/org/apache/eventmesh/trace/api/TracePluginFactoryTest.java
+++ b/eventmesh-trace-plugin/eventmesh-trace-api/src/test/java/org/apache/eventmesh/trace/api/TracePluginFactoryTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.trace.api;
+
+import org.apache.eventmesh.trace.zipkin.ZipkinTraceService;
+
+import static org.hamcrest.CoreMatchers.is;
+
+import org.hamcrest.MatcherAssert;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TracePluginFactoryTest {
+
+    @Test
+    public void testFailedGetTraceService() {
+        NullPointerException nullPointerException1 = Assert.assertThrows(NullPointerException.class, () -> TracePluginFactory.getTraceService(null));
+        MatcherAssert.assertThat(nullPointerException1.getMessage(), is("traceServiceType cannot be null"));
+
+        String traceServiceType = "non-Existing";
+        NullPointerException nullPointerException2 = Assert.assertThrows(NullPointerException.class, () -> TracePluginFactory.getTraceService(traceServiceType));
+        MatcherAssert.assertThat(nullPointerException2.getMessage(), is("traceServiceType: " + traceServiceType + " is not supported"));
+    }
+
+    @Test
+    public void testSuccessfulGetTraceService() {
+        TraceService zipkinTraceService = TracePluginFactory.getTraceService("zipkin");
+        Assert.assertNotNull(zipkinTraceService);
+        Assert.assertTrue(zipkinTraceService instanceof ZipkinTraceService);
+    }
+}

--- a/eventmesh-trace-plugin/eventmesh-trace-zipkin/build.gradle
+++ b/eventmesh-trace-plugin/eventmesh-trace-zipkin/build.gradle
@@ -30,4 +30,5 @@ dependencies {
 
     testCompileOnly 'org.projectlombok:lombok:1.18.22'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.22'
+    testImplementation "org.mockito:mockito-core"
 }

--- a/eventmesh-trace-plugin/eventmesh-trace-zipkin/src/main/java/org/apache/eventmesh/trace/zipkin/ZipkinTraceService.java
+++ b/eventmesh-trace-plugin/eventmesh-trace-zipkin/src/main/java/org/apache/eventmesh/trace/zipkin/ZipkinTraceService.java
@@ -56,6 +56,8 @@ public class ZipkinTraceService implements TraceService {
 
     private OpenTelemetry openTelemetry;
 
+    private Thread shutdownHook;
+
     @Override
     public void init() {
         //zipkin's config
@@ -92,7 +94,8 @@ public class ZipkinTraceService implements TraceService {
             .setTracerProvider(sdkTracerProvider)
             .build();
 
-        Runtime.getRuntime().addShutdownHook(new Thread(sdkTracerProvider::close));
+        shutdownHook = new Thread(sdkTracerProvider::close);
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
     }
 
     @Override

--- a/eventmesh-trace-plugin/eventmesh-trace-zipkin/src/test/java/org/apache/eventmesh/trace/zipkin/ZipkinTraceServiceTest.java
+++ b/eventmesh-trace-plugin/eventmesh-trace-zipkin/src/test/java/org/apache/eventmesh/trace/zipkin/ZipkinTraceServiceTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.trace.zipkin;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Field;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ZipkinTraceServiceTest {
+
+    @Test
+    public void init() throws NoSuchFieldException, IllegalAccessException {
+        ZipkinTraceService zipkinTraceService = new ZipkinTraceService();
+        zipkinTraceService.init();
+
+        Field sdkTracerProviderField = ZipkinTraceService.class.getDeclaredField("sdkTracerProvider");
+        Field openTelemetryField = ZipkinTraceService.class.getDeclaredField("openTelemetry");
+        Field shutdownHookField = ZipkinTraceService.class.getDeclaredField("shutdownHook");
+        sdkTracerProviderField.setAccessible(true);
+        openTelemetryField.setAccessible(true);
+        shutdownHookField.setAccessible(true);
+
+        SdkTracerProvider sdkTracerProvider = (SdkTracerProvider) sdkTracerProviderField.get(zipkinTraceService);
+        OpenTelemetry openTelemetry = (OpenTelemetry) openTelemetryField.get(zipkinTraceService);
+        Thread shutdownHook = (Thread) shutdownHookField.get(zipkinTraceService);
+
+        Assert.assertNotNull(sdkTracerProvider);
+        Assert.assertNotNull(openTelemetry);
+        Assert.assertNotNull(shutdownHook);
+
+        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> {
+            Runtime.getRuntime().addShutdownHook(shutdownHook);
+        });
+        Assert.assertEquals(illegalArgumentException.getMessage(), "Hook previously registered");
+    }
+
+    @Test
+    public void shutdown() throws NoSuchFieldException, IllegalAccessException {
+        SdkTracerProvider mockSdkTracerProvider = Mockito.mock(SdkTracerProvider.class);
+        ZipkinTraceService zipkinTraceService = new ZipkinTraceService();
+        zipkinTraceService.init();
+        Field sdkTracerProviderField = ZipkinTraceService.class.getDeclaredField("sdkTracerProvider");
+        sdkTracerProviderField.setAccessible(true);
+        sdkTracerProviderField.set(zipkinTraceService, mockSdkTracerProvider);
+
+        zipkinTraceService.shutdown();
+        Mockito.verify(mockSdkTracerProvider, Mockito.times(1)).close();
+    }
+}

--- a/eventmesh-trace-plugin/eventmesh-trace-zipkin/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/eventmesh-trace-plugin/eventmesh-trace-zipkin/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Fixes ISSUE #856.

### Motivation

Add test code for eventmesh-trace-plugin module.

### Modifications

Add unit test for `org/apache/eventmesh/trace/api/TracePluginFactory.java`.

Add unit test for `org/apache/eventmesh/trace/zipkin/config/ZipkinConfiguration.java`.

### Documentation

Not a new feature, thus no doc needed.
