### PR TITLE
[ISSUE #896] Add `ttl` default value when building BatchMessage

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/Constants.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/Constants.java
@@ -39,6 +39,8 @@ public class Constants {
 
     public static final String EVENTMESH_MESSAGE_CONST_TTL = "ttl";
 
+    public static final String DEFAULT_EVENTMESH_MESSAGE_TTL = "4000";
+
     public static final Integer DEFAULT_CLIENT_UNACK = 12;
 
     public static final String CONSTANTS_SERVICE_DESC_ENV = "env";


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes ISSUE #<XXX>`.)
-->

Fixes ISSUE #<896>.

### Motivation

When there is no ttl value in EventMeshMessage properties, invoke `org.apache.eventmesh.client.grpc.util.EventMeshClientUtil#buildBatchMessages` method will throw a NPE.

### Modifications

Add a default value when there is no value in EventMeshMessage properties when building BatchMessage.

### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
