### PR TITLE
[Go SDK] Update licenserrc.yaml to ignore go.sum

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -34,6 +34,7 @@ header:
     - '**/*.ini'
     - '**/*.crt'
     - '**/*.pem'
+    - '**/go.sum'
     - 'LICENSE'
     - 'NOTICE'
     - 'DISCLAIMER-WIP'


### PR DESCRIPTION
- update licenserrc.yaml ignore go.sum
- add license header for some go files