### PR TITLE
[ISSUE #923] Fix the key when removing item from ClientGroupMap

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/group/ClientSessionGroupMapping.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/group/ClientSessionGroupMapping.java
@@ -337,9 +337,9 @@ public class ClientSessionGroupMapping {
                 && (session.getClientGroupWrapper().get().getGroupProducerSessions().size() == 0)) {
             shutdownClientGroupProducer(session);
 
-            clientGroupMap.remove(session.getClientGroupWrapper().get().getSysId());
-            lockMap.remove(session.getClientGroupWrapper().get().getSysId());
-            logger.info("remove clientGroupWrapper subsystem[{}]", session.getClientGroupWrapper().get().getSysId());
+            clientGroupMap.remove(session.getClientGroupWrapper().get().getGroup());
+            lockMap.remove(session.getClientGroupWrapper().get().getGroup());
+            logger.info("remove clientGroupWrapper group[{}]", session.getClientGroupWrapper().get().getGroup());
         }
     }
 


### PR DESCRIPTION
Fixes ISSUE #923 

### Motivation

- Removing the ClientGroupWrapper from map not work, because the key is not right.



### Modifications

- Modify the removed key same with when putted.




