### PR TITLE
[ISSUE #957] add trace for http protocol in eventmesh-runtime

### DIFF
--- a/eventmesh-protocol-plugin/eventmesh-protocol-meshmessage/src/main/java/org/apache/eventmesh/protocol/meshmessage/resolver/http/SendMessageRequestProtocolResolver.java
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-meshmessage/src/main/java/org/apache/eventmesh/protocol/meshmessage/resolver/http/SendMessageRequestProtocolResolver.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.SpecVersion;
@@ -64,59 +65,69 @@ public class SendMessageRequestProtocolResolver {
                 cloudEventBuilder = CloudEventBuilder.v1();
 
                 cloudEventBuilder = cloudEventBuilder.withId(sendMessageRequestBody.getBizSeqNo())
-                        .withSubject(sendMessageRequestBody.getTopic())
-                        .withType("eventmeshmessage")
-                        .withSource(URI.create("/"))
-                        .withData(content.getBytes(StandardCharsets.UTF_8))
-                        .withExtension(ProtocolKey.REQUEST_CODE, code)
-                        .withExtension(ProtocolKey.ClientInstanceKey.ENV, env)
-                        .withExtension(ProtocolKey.ClientInstanceKey.IDC, idc)
-                        .withExtension(ProtocolKey.ClientInstanceKey.IP, ip)
-                        .withExtension(ProtocolKey.ClientInstanceKey.PID, pid)
-                        .withExtension(ProtocolKey.ClientInstanceKey.SYS, sys)
-                        .withExtension(ProtocolKey.ClientInstanceKey.USERNAME, username)
-                        .withExtension(ProtocolKey.ClientInstanceKey.PASSWD, passwd)
-                        .withExtension(ProtocolKey.VERSION, version.getVersion())
-                        .withExtension(ProtocolKey.LANGUAGE, language)
-                        .withExtension(ProtocolKey.PROTOCOL_TYPE, protocolType)
-                        .withExtension(ProtocolKey.PROTOCOL_DESC, protocolDesc)
-                        .withExtension(ProtocolKey.PROTOCOL_VERSION, protocolVersion)
-                        .withExtension(SendMessageRequestBody.BIZSEQNO, sendMessageRequestBody.getBizSeqNo())
-                        .withExtension(SendMessageRequestBody.UNIQUEID, sendMessageRequestBody.getUniqueId())
-                        .withExtension(SendMessageRequestBody.PRODUCERGROUP,
-                                sendMessageRequestBody.getProducerGroup())
-                        .withExtension(SendMessageRequestBody.TTL, sendMessageRequestBody.getTtl());
+                    .withSubject(sendMessageRequestBody.getTopic())
+                    .withType("eventmeshmessage")
+                    .withSource(URI.create("/"))
+                    .withData(content.getBytes(StandardCharsets.UTF_8))
+                    .withExtension(ProtocolKey.REQUEST_CODE, code)
+                    .withExtension(ProtocolKey.ClientInstanceKey.ENV, env)
+                    .withExtension(ProtocolKey.ClientInstanceKey.IDC, idc)
+                    .withExtension(ProtocolKey.ClientInstanceKey.IP, ip)
+                    .withExtension(ProtocolKey.ClientInstanceKey.PID, pid)
+                    .withExtension(ProtocolKey.ClientInstanceKey.SYS, sys)
+                    .withExtension(ProtocolKey.ClientInstanceKey.USERNAME, username)
+                    .withExtension(ProtocolKey.ClientInstanceKey.PASSWD, passwd)
+                    .withExtension(ProtocolKey.VERSION, version.getVersion())
+                    .withExtension(ProtocolKey.LANGUAGE, language)
+                    .withExtension(ProtocolKey.PROTOCOL_TYPE, protocolType)
+                    .withExtension(ProtocolKey.PROTOCOL_DESC, protocolDesc)
+                    .withExtension(ProtocolKey.PROTOCOL_VERSION, protocolVersion)
+                    .withExtension(SendMessageRequestBody.BIZSEQNO, sendMessageRequestBody.getBizSeqNo())
+                    .withExtension(SendMessageRequestBody.UNIQUEID, sendMessageRequestBody.getUniqueId())
+                    .withExtension(SendMessageRequestBody.PRODUCERGROUP,
+                        sendMessageRequestBody.getProducerGroup())
+                    .withExtension(SendMessageRequestBody.TTL, sendMessageRequestBody.getTtl());
                 if (StringUtils.isNotEmpty(sendMessageRequestBody.getTag())) {
                     cloudEventBuilder = cloudEventBuilder.withExtension(SendMessageRequestBody.TAG, sendMessageRequestBody.getTag());
+                }
+                if (sendMessageRequestBody.getExtFields() != null && sendMessageRequestBody.getExtFields().size() > 0) {
+                    for (Map.Entry<String, String> entry : sendMessageRequestBody.getExtFields().entrySet()) {
+                        cloudEventBuilder = cloudEventBuilder.withExtension(entry.getKey(), entry.getValue());
+                    }
                 }
                 event = cloudEventBuilder.build();
             } else if (StringUtils.equals(SpecVersion.V03.toString(), protocolVersion)) {
                 cloudEventBuilder = CloudEventBuilder.v03();
                 cloudEventBuilder = cloudEventBuilder.withId(sendMessageRequestBody.getBizSeqNo())
-                        .withSubject(sendMessageRequestBody.getTopic())
-                        .withType("eventmeshmessage")
-                        .withSource(URI.create("/"))
-                        .withData(content.getBytes(StandardCharsets.UTF_8))
-                        .withExtension(ProtocolKey.REQUEST_CODE, code)
-                        .withExtension(ProtocolKey.ClientInstanceKey.ENV, env)
-                        .withExtension(ProtocolKey.ClientInstanceKey.IDC, idc)
-                        .withExtension(ProtocolKey.ClientInstanceKey.IP, ip)
-                        .withExtension(ProtocolKey.ClientInstanceKey.PID, pid)
-                        .withExtension(ProtocolKey.ClientInstanceKey.SYS, sys)
-                        .withExtension(ProtocolKey.ClientInstanceKey.USERNAME, username)
-                        .withExtension(ProtocolKey.ClientInstanceKey.PASSWD, passwd)
-                        .withExtension(ProtocolKey.VERSION, version.getVersion())
-                        .withExtension(ProtocolKey.LANGUAGE, language)
-                        .withExtension(ProtocolKey.PROTOCOL_TYPE, protocolType)
-                        .withExtension(ProtocolKey.PROTOCOL_DESC, protocolDesc)
-                        .withExtension(ProtocolKey.PROTOCOL_VERSION, protocolVersion)
-                        .withExtension(SendMessageRequestBody.BIZSEQNO, sendMessageRequestBody.getBizSeqNo())
-                        .withExtension(SendMessageRequestBody.UNIQUEID, sendMessageRequestBody.getUniqueId())
-                        .withExtension(SendMessageRequestBody.PRODUCERGROUP,
-                                sendMessageRequestBody.getProducerGroup())
-                        .withExtension(SendMessageRequestBody.TTL, sendMessageRequestBody.getTtl());
+                    .withSubject(sendMessageRequestBody.getTopic())
+                    .withType("eventmeshmessage")
+                    .withSource(URI.create("/"))
+                    .withData(content.getBytes(StandardCharsets.UTF_8))
+                    .withExtension(ProtocolKey.REQUEST_CODE, code)
+                    .withExtension(ProtocolKey.ClientInstanceKey.ENV, env)
+                    .withExtension(ProtocolKey.ClientInstanceKey.IDC, idc)
+                    .withExtension(ProtocolKey.ClientInstanceKey.IP, ip)
+                    .withExtension(ProtocolKey.ClientInstanceKey.PID, pid)
+                    .withExtension(ProtocolKey.ClientInstanceKey.SYS, sys)
+                    .withExtension(ProtocolKey.ClientInstanceKey.USERNAME, username)
+                    .withExtension(ProtocolKey.ClientInstanceKey.PASSWD, passwd)
+                    .withExtension(ProtocolKey.VERSION, version.getVersion())
+                    .withExtension(ProtocolKey.LANGUAGE, language)
+                    .withExtension(ProtocolKey.PROTOCOL_TYPE, protocolType)
+                    .withExtension(ProtocolKey.PROTOCOL_DESC, protocolDesc)
+                    .withExtension(ProtocolKey.PROTOCOL_VERSION, protocolVersion)
+                    .withExtension(SendMessageRequestBody.BIZSEQNO, sendMessageRequestBody.getBizSeqNo())
+                    .withExtension(SendMessageRequestBody.UNIQUEID, sendMessageRequestBody.getUniqueId())
+                    .withExtension(SendMessageRequestBody.PRODUCERGROUP,
+                        sendMessageRequestBody.getProducerGroup())
+                    .withExtension(SendMessageRequestBody.TTL, sendMessageRequestBody.getTtl());
                 if (StringUtils.isNotEmpty(sendMessageRequestBody.getTag())) {
                     cloudEventBuilder = cloudEventBuilder.withExtension(SendMessageRequestBody.TAG, sendMessageRequestBody.getTag());
+                }
+                if (sendMessageRequestBody.getExtFields() != null && sendMessageRequestBody.getExtFields().size() > 0) {
+                    for (Map.Entry<String, String> entry : sendMessageRequestBody.getExtFields().entrySet()) {
+                        cloudEventBuilder = cloudEventBuilder.withExtension(entry.getKey(), entry.getValue());
+                    }
                 }
                 event = cloudEventBuilder.build();
             }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/AbstractHTTPServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/AbstractHTTPServer.java
@@ -51,10 +51,13 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFuture;
@@ -297,43 +300,43 @@ public abstract class AbstractHTTPServer extends AbstractRemotingServer {
 
         @Override
         protected void channelRead0(ChannelHandlerContext ctx, HttpRequest httpRequest) {
-//            Context context = null;
-//            Span span = null;
-//            if (useTrace) {
-//
-//                //if the client injected span context,this will extract the context from httpRequest or it will be null
-//                context = textMapPropagator.extract(Context.current(), httpRequest, new TextMapGetter<HttpRequest>() {
-//                    @Override
-//                    public Iterable<String> keys(HttpRequest carrier) {
-//                        return carrier.headers().names();
-//                    }
-//
-//                    @Override
-//                    public String get(HttpRequest carrier, String key) {
-//                        return carrier.headers().get(key);
-//                    }
-//                });
-//
-//                span = tracer.spanBuilder("HTTP " + httpRequest.method())
-//                        .setParent(context)
-//                        .setSpanKind(SpanKind.SERVER)
-//                        .startSpan();
-//                //attach the span to the server context
-//                context = context.with(SpanKey.SERVER_KEY, span);
-//                //put the context in channel
-//                ctx.channel().attr(AttributeKeys.SERVER_CONTEXT).set(context);
-//            }
+            //            Context context = null;
+            //            Span span = null;
+            //            if (useTrace) {
+            //
+            //                //if the client injected span context,this will extract the context from httpRequest or it will be null
+            //                context = textMapPropagator.extract(Context.current(), httpRequest, new TextMapGetter<HttpRequest>() {
+            //                    @Override
+            //                    public Iterable<String> keys(HttpRequest carrier) {
+            //                        return carrier.headers().names();
+            //                    }
+            //
+            //                    @Override
+            //                    public String get(HttpRequest carrier, String key) {
+            //                        return carrier.headers().get(key);
+            //                    }
+            //                });
+            //
+            //                span = tracer.spanBuilder("HTTP " + httpRequest.method())
+            //                        .setParent(context)
+            //                        .setSpanKind(SpanKind.SERVER)
+            //                        .startSpan();
+            //                //attach the span to the server context
+            //                context = context.with(SpanKey.SERVER_KEY, span);
+            //                //put the context in channel
+            //                ctx.channel().attr(AttributeKeys.SERVER_CONTEXT).set(context);
+            //            }
 
 
 
             Span span = null;
-//            Context context = null;
-//            context = EventMeshServer.getTrace().extractFrom();
-//            span = EventMeshServer.getTrace().createSpan("", context);
-//            //attach the span to the server context
-//            context = context.with(SpanKey.SERVER_KEY, span);
-//            //put the context in channel
-//            ctx.channel().attr(AttributeKeys.SERVER_CONTEXT).set(context);
+            //            Context context = null;
+            //            context = EventMeshServer.getTrace().extractFrom();
+            //            span = EventMeshServer.getTrace().createSpan("", context);
+            //            //attach the span to the server context
+            //            context = context.with(SpanKey.SERVER_KEY, span);
+            //            //put the context in channel
+            //            ctx.channel().attr(AttributeKeys.SERVER_CONTEXT).set(context);
 
             try {
                 preProcessHttpRequestHeader(ctx, httpRequest);
@@ -384,11 +387,11 @@ public abstract class AbstractHTTPServer extends AbstractRemotingServer {
                     requestCommand.setHttpVersion(httpRequest.protocolVersion().protocolName());
                     requestCommand.setRequestCode(requestCode);
 
-//                if (useTrace) {
-//                    span.setAttribute(SemanticAttributes.HTTP_METHOD, httpRequest.method().name());
-//                    span.setAttribute(SemanticAttributes.HTTP_FLAVOR, httpRequest.protocolVersion().protocolName());
-//                    span.setAttribute(String.valueOf(SemanticAttributes.HTTP_STATUS_CODE), requestCode);
-//                }
+                    //                if (useTrace) {
+                    //                    span.setAttribute(SemanticAttributes.HTTP_METHOD, httpRequest.method().name());
+                    //                    span.setAttribute(SemanticAttributes.HTTP_FLAVOR, httpRequest.protocolVersion().protocolName());
+                    //                    span.setAttribute(String.valueOf(SemanticAttributes.HTTP_STATUS_CODE), requestCode);
+                    //                }
 
                     HttpCommand responseCommand = null;
 
@@ -428,8 +431,6 @@ public abstract class AbstractHTTPServer extends AbstractRemotingServer {
 
             } catch (Exception ex) {
                 httpServerLogger.error("AbrstractHTTPServer.HTTPHandler.channelRead0 err", ex);
-
-//                EventMeshServer.getTrace().finishSpan(span, null, null, ex);
             }
         }
 
@@ -514,8 +515,10 @@ public abstract class AbstractHTTPServer extends AbstractRemotingServer {
                                 sendResponse(ctx, responseCommand.httpResponse());
 
                                 Map<String, Object> traceMap = asyncContext.getRequest().getHeader().toMap();
-                                Span span = TraceUtils.prepareServerSpan(traceMap, EventMeshTraceConstants.TRACE_UPSTREAM_EVENTMESH_SERVER_SPAN, false);
-                                TraceUtils.finishSpanWithException(span, traceMap, EventMeshRetCode.EVENTMESH_REJECT_BY_PROCESSOR_ERROR.getErrMsg(), null);
+                                Span span = TraceUtils.prepareServerSpan(traceMap, EventMeshTraceConstants.TRACE_UPSTREAM_EVENTMESH_SERVER_SPAN,
+                                    false);
+                                TraceUtils.finishSpanWithException(span, traceMap,
+                                    EventMeshRetCode.EVENTMESH_REJECT_BY_PROCESSOR_ERROR.getErrMsg(), null);
                             }
                             return;
                         }
@@ -534,8 +537,6 @@ public abstract class AbstractHTTPServer extends AbstractRemotingServer {
 
                         sendResponse(ctx, asyncContext.getResponse().httpResponse());
 
-//                        EventMeshServer.getTrace().finishSpan(ctx, StatusCode.OK);
-
                     } catch (Exception e) {
                         httpServerLogger.error("process error", e);
                     }
@@ -551,7 +552,6 @@ public abstract class AbstractHTTPServer extends AbstractRemotingServer {
                     Map<String, Object> traceMap = asyncContext.getRequest().getHeader().toMap();
                     Span span = TraceUtils.prepareServerSpan(traceMap, EventMeshTraceConstants.TRACE_UPSTREAM_EVENTMESH_SERVER_SPAN, false);
                     TraceUtils.finishSpanWithException(span, traceMap, EventMeshRetCode.EVENTMESH_RUNTIME_ERR.getErrMsg(), re);
-//                    EventMeshServer.getTrace().finishSpan(ctx, StatusCode.ERROR, EventMeshRetCode.OVERLOAD.getErrMsg(), re);
                 } catch (Exception e) {
                     httpServerLogger.error("processEventMeshRequest fail", re);
                 }
@@ -574,7 +574,7 @@ public abstract class AbstractHTTPServer extends AbstractRemotingServer {
             }
         }
 
-        Map<String, String> extractFromRequest(HttpRequest httpRequest){
+        Map<String, String> extractFromRequest(HttpRequest httpRequest) {
             return null;
         }
     }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshHTTPServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshHTTPServer.java
@@ -38,9 +38,12 @@ import org.apache.eventmesh.runtime.core.protocol.http.processor.BatchSendMessag
 import org.apache.eventmesh.runtime.core.protocol.http.processor.HeartBeatProcessor;
 import org.apache.eventmesh.runtime.core.protocol.http.processor.LocalSubscribeEventProcessor;
 import org.apache.eventmesh.runtime.core.protocol.http.processor.LocalUnSubscribeEventProcessor;
+import org.apache.eventmesh.runtime.core.protocol.http.processor.RemoteSubscribeEventProcessor;
+import org.apache.eventmesh.runtime.core.protocol.http.processor.RemoteUnSubscribeEventProcessor;
 import org.apache.eventmesh.runtime.core.protocol.http.processor.ReplyMessageProcessor;
 import org.apache.eventmesh.runtime.core.protocol.http.processor.SendAsyncEventProcessor;
 import org.apache.eventmesh.runtime.core.protocol.http.processor.SendAsyncMessageProcessor;
+import org.apache.eventmesh.runtime.core.protocol.http.processor.SendAsyncRemoteEventProcessor;
 import org.apache.eventmesh.runtime.core.protocol.http.processor.SendSyncMessageProcessor;
 import org.apache.eventmesh.runtime.core.protocol.http.processor.SubscribeProcessor;
 import org.apache.eventmesh.runtime.core.protocol.http.processor.UnSubscribeProcessor;
@@ -342,6 +345,9 @@ public class EventMeshHTTPServer extends AbstractHTTPServer {
         SendAsyncEventProcessor sendAsyncEventProcessor = new SendAsyncEventProcessor(this);
         registerProcessor(RequestURI.PUBLISH.getRequestURI(), sendAsyncEventProcessor, sendMsgExecutor);
 
+        SendAsyncRemoteEventProcessor sendAsyncRemoteEventProcessor = new SendAsyncRemoteEventProcessor(this);
+        registerProcessor(RequestURI.PUBLISH_BRIDGE.getRequestURI(), sendAsyncRemoteEventProcessor, remoteMsgExecutor);
+
         AdminMetricsProcessor adminMetricsProcessor = new AdminMetricsProcessor(this);
         registerProcessor(RequestCode.ADMIN_METRICS.getRequestCode(), adminMetricsProcessor, adminExecutor);
 
@@ -354,11 +360,17 @@ public class EventMeshHTTPServer extends AbstractHTTPServer {
         LocalSubscribeEventProcessor localSubscribeEventProcessor = new LocalSubscribeEventProcessor(this);
         registerProcessor(RequestURI.SUBSCRIBE_LOCAL.getRequestURI(), localSubscribeEventProcessor, clientManageExecutor);
 
+        RemoteSubscribeEventProcessor remoteSubscribeEventProcessor = new RemoteSubscribeEventProcessor(this);
+        registerProcessor(RequestURI.SUBSCRIBE_REMOTE.getRequestURI(), remoteSubscribeEventProcessor, clientManageExecutor);
+
         UnSubscribeProcessor unSubscribeProcessor = new UnSubscribeProcessor(this);
         registerProcessor(RequestCode.UNSUBSCRIBE.getRequestCode(), unSubscribeProcessor, clientManageExecutor);
 
         LocalUnSubscribeEventProcessor localUnSubscribeEventProcessor = new LocalUnSubscribeEventProcessor(this);
         registerProcessor(RequestURI.UNSUBSCRIBE_LOCAL.getRequestURI(), localUnSubscribeEventProcessor, clientManageExecutor);
+
+        RemoteUnSubscribeEventProcessor remoteUnSubscribeEventProcessor = new RemoteUnSubscribeEventProcessor(this);
+        registerProcessor(RequestURI.UNSUBSCRIBE_REMOTE.getRequestURI(), remoteUnSubscribeEventProcessor, clientManageExecutor);
 
         ReplyMessageProcessor replyMessageProcessor = new ReplyMessageProcessor(this);
         registerProcessor(RequestCode.REPLY_MESSAGE.getRequestCode(), replyMessageProcessor, replyMsgExecutor);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshHTTPServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshHTTPServer.java
@@ -38,12 +38,9 @@ import org.apache.eventmesh.runtime.core.protocol.http.processor.BatchSendMessag
 import org.apache.eventmesh.runtime.core.protocol.http.processor.HeartBeatProcessor;
 import org.apache.eventmesh.runtime.core.protocol.http.processor.LocalSubscribeEventProcessor;
 import org.apache.eventmesh.runtime.core.protocol.http.processor.LocalUnSubscribeEventProcessor;
-import org.apache.eventmesh.runtime.core.protocol.http.processor.RemoteSubscribeEventProcessor;
-import org.apache.eventmesh.runtime.core.protocol.http.processor.RemoteUnSubscribeEventProcessor;
 import org.apache.eventmesh.runtime.core.protocol.http.processor.ReplyMessageProcessor;
 import org.apache.eventmesh.runtime.core.protocol.http.processor.SendAsyncEventProcessor;
 import org.apache.eventmesh.runtime.core.protocol.http.processor.SendAsyncMessageProcessor;
-import org.apache.eventmesh.runtime.core.protocol.http.processor.SendAsyncRemoteEventProcessor;
 import org.apache.eventmesh.runtime.core.protocol.http.processor.SendSyncMessageProcessor;
 import org.apache.eventmesh.runtime.core.protocol.http.processor.SubscribeProcessor;
 import org.apache.eventmesh.runtime.core.protocol.http.processor.UnSubscribeProcessor;
@@ -86,7 +83,7 @@ public class EventMeshHTTPServer extends AbstractHTTPServer {
 
     public EventMeshHTTPServer(EventMeshServer eventMeshServer,
                                EventMeshHTTPConfiguration eventMeshHttpConfiguration) {
-        super(eventMeshHttpConfiguration.httpServerPort, eventMeshHttpConfiguration.eventMeshServerUseTls);
+        super(eventMeshHttpConfiguration.httpServerPort, eventMeshHttpConfiguration.eventMeshServerUseTls, eventMeshHttpConfiguration);
         this.eventMeshServer = eventMeshServer;
         this.eventMeshHttpConfiguration = eventMeshHttpConfiguration;
         this.registry = eventMeshServer.getRegistry();
@@ -249,7 +246,7 @@ public class EventMeshHTTPServer extends AbstractHTTPServer {
         //get the trace-plugin
         if (StringUtils.isNotEmpty(eventMeshHttpConfiguration.eventMeshTracePluginType) && eventMeshHttpConfiguration.eventMeshServerTraceEnable) {
 
-            super.useTrace = true;
+            super.useTrace = eventMeshHttpConfiguration.eventMeshServerTraceEnable;
         }
 
         logger.info("--------------------------EventMeshHTTPServer inited");
@@ -339,9 +336,6 @@ public class EventMeshHTTPServer extends AbstractHTTPServer {
         SendAsyncEventProcessor sendAsyncEventProcessor = new SendAsyncEventProcessor(this);
         registerProcessor(RequestURI.PUBLISH.getRequestURI(), sendAsyncEventProcessor, sendMsgExecutor);
 
-        SendAsyncRemoteEventProcessor sendAsyncRemoteEventProcessor = new SendAsyncRemoteEventProcessor(this);
-        registerProcessor(RequestURI.PUBLISH_BRIDGE.getRequestURI(), sendAsyncRemoteEventProcessor, remoteMsgExecutor);
-
         AdminMetricsProcessor adminMetricsProcessor = new AdminMetricsProcessor(this);
         registerProcessor(RequestCode.ADMIN_METRICS.getRequestCode(), adminMetricsProcessor, adminExecutor);
 
@@ -354,17 +348,11 @@ public class EventMeshHTTPServer extends AbstractHTTPServer {
         LocalSubscribeEventProcessor localSubscribeEventProcessor = new LocalSubscribeEventProcessor(this);
         registerProcessor(RequestURI.SUBSCRIBE_LOCAL.getRequestURI(), localSubscribeEventProcessor, clientManageExecutor);
 
-        RemoteSubscribeEventProcessor remoteSubscribeEventProcessor = new RemoteSubscribeEventProcessor(this);
-        registerProcessor(RequestURI.SUBSCRIBE_REMOTE.getRequestURI(), remoteSubscribeEventProcessor, clientManageExecutor);
-
         UnSubscribeProcessor unSubscribeProcessor = new UnSubscribeProcessor(this);
         registerProcessor(RequestCode.UNSUBSCRIBE.getRequestCode(), unSubscribeProcessor, clientManageExecutor);
 
         LocalUnSubscribeEventProcessor localUnSubscribeEventProcessor = new LocalUnSubscribeEventProcessor(this);
         registerProcessor(RequestURI.UNSUBSCRIBE_LOCAL.getRequestURI(), localUnSubscribeEventProcessor, clientManageExecutor);
-
-        RemoteUnSubscribeEventProcessor remoteUnSubscribeEventProcessor = new RemoteUnSubscribeEventProcessor(this);
-        registerProcessor(RequestURI.UNSUBSCRIBE_REMOTE.getRequestURI(), remoteUnSubscribeEventProcessor, clientManageExecutor);
 
         ReplyMessageProcessor replyMessageProcessor = new ReplyMessageProcessor(this);
         registerProcessor(RequestCode.REPLY_MESSAGE.getRequestCode(), replyMessageProcessor, replyMsgExecutor);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/EventMeshConsumer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/EventMeshConsumer.java
@@ -37,11 +37,14 @@ import org.apache.eventmesh.runtime.core.protocol.http.producer.EventMeshProduce
 import org.apache.eventmesh.runtime.core.protocol.http.producer.SendMessageContext;
 import org.apache.eventmesh.runtime.core.protocol.http.push.HTTPMessageHandler;
 import org.apache.eventmesh.runtime.core.protocol.http.push.MessageHandler;
+import org.apache.eventmesh.runtime.trace.TraceUtils;
 import org.apache.eventmesh.runtime.util.EventMeshUtil;
+import org.apache.eventmesh.trace.api.common.EventMeshTraceConstants;
 
 import org.apache.commons.collections4.MapUtils;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -50,6 +53,8 @@ import org.slf4j.LoggerFactory;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
 
 public class EventMeshConsumer {
 
@@ -89,55 +94,67 @@ public class EventMeshConsumer {
         keyValue.put("consumerGroup", consumerGroupConf.getConsumerGroup());
         keyValue.put("eventMeshIDC", eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshIDC);
         keyValue.put("instanceName", EventMeshUtil.buildMeshClientID(consumerGroupConf.getConsumerGroup(),
-                eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshCluster));
+            eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshCluster));
         persistentMqConsumer.init(keyValue);
 
         EventListener cluserEventListener = new EventListener() {
             @Override
             public void consume(CloudEvent event, AsyncConsumeContext context) {
-                String topic = event.getSubject();
-                String bizSeqNo = (String) event.getExtension(Constants.PROPERTY_MESSAGE_SEARCH_KEYS);
-                String uniqueId = (String) event.getExtension(Constants.RMB_UNIQ_ID);
+                String protocolVersion =
+                    Objects.requireNonNull(event.getExtension(Constants.PROTOCOL_VERSION)).toString();
 
-                event = CloudEventBuilder.from(event)
-                    .withExtension(EventMeshConstants.REQ_MQ2EVENTMESH_TIMESTAMP, String.valueOf(System.currentTimeMillis()))
-                    .build();
-                if (messageLogger.isDebugEnabled()) {
-                    messageLogger.debug("message|mq2eventMesh|topic={}|event={}", topic, event);
-                } else {
-                    messageLogger.info("message|mq2eventMesh|topic={}|bizSeqNo={}|uniqueId={}", topic, bizSeqNo, uniqueId);
-                }
+                Span span = TraceUtils.prepareServerSpan(
+                    EventMeshUtil.getCloudEventExtensionMap(protocolVersion, event),
+                    EventMeshTraceConstants.TRACE_DOWNSTREAM_EVENTMESH_SERVER_SPAN, false);
+                try (Scope scope = span.makeCurrent()) {
+                    String topic = event.getSubject();
+                    String bizSeqNo = (String) event.getExtension(Constants.PROPERTY_MESSAGE_SEARCH_KEYS);
+                    String uniqueId = (String) event.getExtension(Constants.RMB_UNIQ_ID);
 
-                ConsumerGroupTopicConf currentTopicConfig = MapUtils.getObject(consumerGroupConf.getConsumerGroupTopicConf(),
-                    topic, null);
-                EventMeshAsyncConsumeContext eventMeshAsyncConsumeContext = (EventMeshAsyncConsumeContext) context;
+                    event = CloudEventBuilder.from(event)
+                        .withExtension(EventMeshConstants.REQ_MQ2EVENTMESH_TIMESTAMP, String.valueOf(System.currentTimeMillis()))
+                        .withExtension(EventMeshConstants.REQ_RECEIVE_EVENTMESH_IP,
+                            eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshServerIp)
+                        .build();
+                    if (messageLogger.isDebugEnabled()) {
+                        messageLogger.debug("message|mq2eventMesh|topic={}|event={}", topic, event);
+                    } else {
+                        messageLogger.info("message|mq2eventMesh|topic={}|bizSeqNo={}|uniqueId={}", topic, bizSeqNo, uniqueId);
+                    }
 
-                if (currentTopicConfig == null) {
-                    logger.error("no topicConfig found, consumerGroup:{} topic:{}", consumerGroupConf.getConsumerGroup(), topic);
-                    try {
-                        sendMessageBack(event, uniqueId, bizSeqNo);
+                    ConsumerGroupTopicConf currentTopicConfig = MapUtils.getObject(consumerGroupConf.getConsumerGroupTopicConf(),
+                        topic, null);
+                    EventMeshAsyncConsumeContext eventMeshAsyncConsumeContext = (EventMeshAsyncConsumeContext) context;
+
+                    if (currentTopicConfig == null) {
+                        logger.error("no topicConfig found, consumerGroup:{} topic:{}", consumerGroupConf.getConsumerGroup(), topic);
+                        try {
+                            sendMessageBack(event, uniqueId, bizSeqNo);
+                            eventMeshAsyncConsumeContext.commit(EventMeshAction.CommitMessage);
+                            return;
+                        } catch (Exception ex) {
+                            //ignore
+                        }
+                    }
+
+                    SubscriptionItem subscriptionItem = consumerGroupConf.getConsumerGroupTopicConf().get(topic).getSubscriptionItem();
+                    HandleMsgContext handleMsgContext = new HandleMsgContext(EventMeshUtil.buildPushMsgSeqNo(),
+                        consumerGroupConf.getConsumerGroup(), EventMeshConsumer.this,
+                        topic, event, subscriptionItem, eventMeshAsyncConsumeContext.getAbstractContext(),
+                        consumerGroupConf, eventMeshHTTPServer, bizSeqNo, uniqueId, currentTopicConfig);
+
+                    if (httpMessageHandler.handle(handleMsgContext)) {
+                        eventMeshAsyncConsumeContext.commit(EventMeshAction.ManualAck);
+                    } else {
+                        try {
+                            sendMessageBack(event, uniqueId, bizSeqNo);
+                        } catch (Exception e) {
+                            //ignore
+                        }
                         eventMeshAsyncConsumeContext.commit(EventMeshAction.CommitMessage);
-                        return;
-                    } catch (Exception ex) {
-                        //ignore
                     }
-                }
-
-                SubscriptionItem subscriptionItem = consumerGroupConf.getConsumerGroupTopicConf().get(topic).getSubscriptionItem();
-                HandleMsgContext handleMsgContext = new HandleMsgContext(EventMeshUtil.buildPushMsgSeqNo(),
-                    consumerGroupConf.getConsumerGroup(), EventMeshConsumer.this,
-                    topic, event, subscriptionItem, eventMeshAsyncConsumeContext.getAbstractContext(),
-                    consumerGroupConf, eventMeshHTTPServer, bizSeqNo, uniqueId, currentTopicConfig);
-
-                if (httpMessageHandler.handle(handleMsgContext)) {
-                    eventMeshAsyncConsumeContext.commit(EventMeshAction.ManualAck);
-                } else {
-                    try {
-                        sendMessageBack(event, uniqueId, bizSeqNo);
-                    } catch (Exception e) {
-                        //ignore
-                    }
-                    eventMeshAsyncConsumeContext.commit(EventMeshAction.CommitMessage);
+                } finally {
+                    TraceUtils.finishSpan(span, event);
                 }
             }
         };
@@ -149,60 +166,81 @@ public class EventMeshConsumer {
         broadcastKeyValue.put("consumerGroup", consumerGroupConf.getConsumerGroup());
         broadcastKeyValue.put("eventMeshIDC", eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshIDC);
         broadcastKeyValue.put("instanceName", EventMeshUtil.buildMeshClientID(consumerGroupConf.getConsumerGroup(),
-                eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshCluster));
+            eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshCluster));
         broadcastMqConsumer.init(broadcastKeyValue);
 
         EventListener broadcastEventListener = new EventListener() {
             @Override
             public void consume(CloudEvent event, AsyncConsumeContext context) {
 
-                event = CloudEventBuilder.from(event)
-                    .withExtension(EventMeshConstants.REQ_MQ2EVENTMESH_TIMESTAMP,
-                        String.valueOf(System.currentTimeMillis()))
-                    .build();
+                String protocolVersion =
+                    Objects.requireNonNull(event.getExtension(Constants.PROTOCOL_VERSION)).toString();
 
-                String topic = event.getSubject();
-                String bizSeqNo = event.getExtension(Constants.PROPERTY_MESSAGE_SEARCH_KEYS).toString();
-                String uniqueId = event.getExtension(Constants.RMB_UNIQ_ID).toString();
+                Span span = TraceUtils.prepareServerSpan(
+                    EventMeshUtil.getCloudEventExtensionMap(protocolVersion, event),
+                    EventMeshTraceConstants.TRACE_DOWNSTREAM_EVENTMESH_SERVER_SPAN, false);
+                try (Scope scope = span.makeCurrent()) {
 
-                if (messageLogger.isDebugEnabled()) {
-                    messageLogger.debug("message|mq2eventMesh|topic={}|msg={}", topic, event);
-                } else {
-                    messageLogger.info("message|mq2eventMesh|topic={}|bizSeqNo={}|uniqueId={}", topic, bizSeqNo,
-                        uniqueId);
-                }
+                    event = CloudEventBuilder.from(event)
+                        .withExtension(EventMeshConstants.REQ_MQ2EVENTMESH_TIMESTAMP,
+                            String.valueOf(System.currentTimeMillis()))
+                        .withExtension(EventMeshConstants.REQ_RECEIVE_EVENTMESH_IP,
+                            eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshServerIp)
+                        .build();
 
-                ConsumerGroupTopicConf currentTopicConfig = MapUtils.getObject(
-                    consumerGroupConf.getConsumerGroupTopicConf(), topic, null);
-                EventMeshAsyncConsumeContext eventMeshAsyncConsumeContext = (EventMeshAsyncConsumeContext) context;
+                    String topic = event.getSubject();
+                    String bizSeqNo =
+                        event.getExtension(Constants.PROPERTY_MESSAGE_SEARCH_KEYS).toString();
+                    String uniqueId = event.getExtension(Constants.RMB_UNIQ_ID).toString();
 
-                if (currentTopicConfig == null) {
-                    logger.error("no topicConfig found, consumerGroup:{} topic:{}",
-                        consumerGroupConf.getConsumerGroup(), topic);
-                    try {
-                        sendMessageBack(event, uniqueId, bizSeqNo);
+                    if (messageLogger.isDebugEnabled()) {
+                        messageLogger.debug("message|mq2eventMesh|topic={}|msg={}", topic, event);
+                    } else {
+                        messageLogger.info("message|mq2eventMesh|topic={}|bizSeqNo={}|uniqueId={}",
+                            topic, bizSeqNo,
+                            uniqueId);
+                    }
+
+                    ConsumerGroupTopicConf currentTopicConfig = MapUtils.getObject(
+                        consumerGroupConf.getConsumerGroupTopicConf(), topic, null);
+                    EventMeshAsyncConsumeContext eventMeshAsyncConsumeContext =
+                        (EventMeshAsyncConsumeContext) context;
+
+                    if (currentTopicConfig == null) {
+                        logger.error("no topicConfig found, consumerGroup:{} topic:{}",
+                            consumerGroupConf.getConsumerGroup(), topic);
+                        try {
+                            sendMessageBack(event, uniqueId, bizSeqNo);
+                            eventMeshAsyncConsumeContext.commit(EventMeshAction.CommitMessage);
+                            return;
+                        } catch (Exception ex) {
+                            //ignore
+                        }
+                    }
+
+                    SubscriptionItem subscriptionItem =
+                        consumerGroupConf.getConsumerGroupTopicConf().get(topic)
+                            .getSubscriptionItem();
+                    HandleMsgContext handleMsgContext =
+                        new HandleMsgContext(EventMeshUtil.buildPushMsgSeqNo(),
+                            consumerGroupConf.getConsumerGroup(), EventMeshConsumer.this,
+                            topic, event, subscriptionItem,
+                            eventMeshAsyncConsumeContext.getAbstractContext(),
+                            consumerGroupConf, eventMeshHTTPServer, bizSeqNo, uniqueId,
+                            currentTopicConfig);
+
+                    if (httpMessageHandler.handle(handleMsgContext)) {
+                        eventMeshAsyncConsumeContext.commit(EventMeshAction.ManualAck);
+                    } else {
+                        try {
+                            sendMessageBack(event, uniqueId, bizSeqNo);
+                        } catch (Exception e) {
+                            //ignore
+                        }
                         eventMeshAsyncConsumeContext.commit(EventMeshAction.CommitMessage);
-                        return;
-                    } catch (Exception ex) {
-                        //ignore
                     }
-                }
-
-                SubscriptionItem subscriptionItem = consumerGroupConf.getConsumerGroupTopicConf().get(topic).getSubscriptionItem();
-                HandleMsgContext handleMsgContext = new HandleMsgContext(EventMeshUtil.buildPushMsgSeqNo(),
-                    consumerGroupConf.getConsumerGroup(), EventMeshConsumer.this,
-                    topic, event, subscriptionItem, eventMeshAsyncConsumeContext.getAbstractContext(),
-                    consumerGroupConf, eventMeshHTTPServer, bizSeqNo, uniqueId, currentTopicConfig);
-
-                if (httpMessageHandler.handle(handleMsgContext)) {
-                    eventMeshAsyncConsumeContext.commit(EventMeshAction.ManualAck);
-                } else {
-                    try {
-                        sendMessageBack(event, uniqueId, bizSeqNo);
-                    } catch (Exception e) {
-                        //ignore
-                    }
-                    eventMeshAsyncConsumeContext.commit(EventMeshAction.CommitMessage);
+                } finally {
+                    TraceUtils.finishSpan(span, event);
                 }
             }
         };
@@ -263,16 +301,16 @@ public class EventMeshConsumer {
     public void sendMessageBack(final CloudEvent event, final String uniqueId, String bizSeqNo) throws Exception {
 
         EventMeshProducer sendMessageBack
-                = eventMeshHTTPServer.getProducerManager().getEventMeshProducer(consumerGroupConf.getConsumerGroup());
+            = eventMeshHTTPServer.getProducerManager().getEventMeshProducer(consumerGroupConf.getConsumerGroup());
 
         if (sendMessageBack == null) {
             logger.warn("consumer:{} consume fail, sendMessageBack, bizSeqNo:{}, uniqueId:{}",
-                    consumerGroupConf.getConsumerGroup(), bizSeqNo, uniqueId);
+                consumerGroupConf.getConsumerGroup(), bizSeqNo, uniqueId);
             return;
         }
 
         final SendMessageContext sendMessageBackContext = new SendMessageContext(bizSeqNo, event, sendMessageBack,
-                eventMeshHTTPServer);
+            eventMeshHTTPServer);
 
         sendMessageBack.send(sendMessageBackContext, new SendCallback() {
             @Override
@@ -282,7 +320,7 @@ public class EventMeshConsumer {
             @Override
             public void onException(OnExceptionContext context) {
                 logger.warn("consumer:{} consume fail, sendMessageBack, bizSeqno:{}, uniqueId:{}",
-                        consumerGroupConf.getConsumerGroup(), bizSeqNo, uniqueId);
+                    consumerGroupConf.getConsumerGroup(), bizSeqNo, uniqueId);
             }
         });
     }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/push/AsyncHTTPPushRequest.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/push/AsyncHTTPPushRequest.java
@@ -121,6 +121,8 @@ public class AsyncHTTPPushRequest extends AbstractHTTPPushRequest {
         CloudEvent event = CloudEventBuilder.from(handleMsgContext.getEvent())
             .withExtension(EventMeshConstants.REQ_EVENTMESH2C_TIMESTAMP,
                 String.valueOf(System.currentTimeMillis()))
+            .withExtension(EventMeshConstants.RSP_URL, currPushUrl)
+            .withExtension(EventMeshConstants.RSP_GROUP, handleMsgContext.getConsumerGroup())
             .build();
         handleMsgContext.setEvent(event);
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/push/HTTPMessageHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/push/HTTPMessageHandler.java
@@ -17,13 +17,21 @@
 
 package org.apache.eventmesh.runtime.core.protocol.http.push;
 
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
+
+import org.apache.eventmesh.common.Constants;
 import org.apache.eventmesh.common.ThreadPoolFactory;
 import org.apache.eventmesh.runtime.core.protocol.http.consumer.EventMeshConsumer;
 import org.apache.eventmesh.runtime.core.protocol.http.consumer.HandleMsgContext;
+import org.apache.eventmesh.runtime.trace.TraceUtils;
+import org.apache.eventmesh.runtime.util.EventMeshUtil;
+import org.apache.eventmesh.trace.api.common.EventMeshTraceConstants;
 
 import org.apache.commons.collections4.MapUtils;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -69,22 +77,33 @@ public class HTTPMessageHandler implements MessageHandler {
     @Override
     public boolean handle(final HandleMsgContext handleMsgContext) {
         Set waitingRequests4Group = MapUtils.getObject(waitingRequests,
-                handleMsgContext.getConsumerGroup(), Sets.newConcurrentHashSet());
+            handleMsgContext.getConsumerGroup(), Sets.newConcurrentHashSet());
         if (waitingRequests4Group.size() > CONSUMER_GROUP_WAITING_REQUEST_THRESHOLD) {
             logger.warn("waitingRequests is too many, so reject, this message will be send back to MQ, consumerGroup:{}, threshold:{}",
-                    handleMsgContext.getConsumerGroup(), CONSUMER_GROUP_WAITING_REQUEST_THRESHOLD);
+                handleMsgContext.getConsumerGroup(), CONSUMER_GROUP_WAITING_REQUEST_THRESHOLD);
             return false;
         }
 
         try {
             pushExecutor.submit(() -> {
-                AsyncHTTPPushRequest asyncPushRequest = new AsyncHTTPPushRequest(handleMsgContext, waitingRequests);
-                asyncPushRequest.tryHTTPRequest();
+                String protocolVersion = Objects.requireNonNull(handleMsgContext.getEvent().getExtension(
+                    Constants.PROTOCOL_VERSION)).toString();
+
+                Span span = TraceUtils.prepareClientSpan(
+                    EventMeshUtil.getCloudEventExtensionMap(protocolVersion, handleMsgContext.getEvent()), EventMeshTraceConstants.TRACE_DOWNSTREAM_EVENTMESH_CLIENT_SPAN, false);
+
+                try(Scope scope = span.makeCurrent()){
+                    AsyncHTTPPushRequest asyncPushRequest = new AsyncHTTPPushRequest(handleMsgContext, waitingRequests);
+                    asyncPushRequest.tryHTTPRequest();
+                }finally {
+                    TraceUtils.finishSpan(span, handleMsgContext.getEvent());
+                }
+
             });
             return true;
         } catch (RejectedExecutionException e) {
             logger.warn("pushMsgThreadPoolQueue is full, so reject, current task size {}",
-                    handleMsgContext.getEventMeshHTTPServer().getPushMsgExecutor().getQueue().size(), e);
+                handleMsgContext.getEventMeshHTTPServer().getPushMsgExecutor().getQueue().size(), e);
             return false;
         }
     }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/push/HTTPMessageHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/push/HTTPMessageHandler.java
@@ -17,9 +17,6 @@
 
 package org.apache.eventmesh.runtime.core.protocol.http.push;
 
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.context.Scope;
-
 import org.apache.eventmesh.common.Constants;
 import org.apache.eventmesh.common.ThreadPoolFactory;
 import org.apache.eventmesh.runtime.core.protocol.http.consumer.EventMeshConsumer;
@@ -40,6 +37,8 @@ import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.opentelemetry.api.trace.Span;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -89,13 +88,13 @@ public class HTTPMessageHandler implements MessageHandler {
                 String protocolVersion = Objects.requireNonNull(handleMsgContext.getEvent().getExtension(
                     Constants.PROTOCOL_VERSION)).toString();
 
-                Span span = TraceUtils.prepareClientSpan(
-                    EventMeshUtil.getCloudEventExtensionMap(protocolVersion, handleMsgContext.getEvent()), EventMeshTraceConstants.TRACE_DOWNSTREAM_EVENTMESH_CLIENT_SPAN, false);
+                Span span = TraceUtils.prepareClientSpan(EventMeshUtil.getCloudEventExtensionMap(protocolVersion, handleMsgContext.getEvent()),
+                    EventMeshTraceConstants.TRACE_DOWNSTREAM_EVENTMESH_CLIENT_SPAN, false);
 
-                try(Scope scope = span.makeCurrent()){
+                try {
                     AsyncHTTPPushRequest asyncPushRequest = new AsyncHTTPPushRequest(handleMsgContext, waitingRequests);
                     asyncPushRequest.tryHTTPRequest();
-                }finally {
+                } finally {
                     TraceUtils.finishSpan(span, handleMsgContext.getEvent());
                 }
 


### PR DESCRIPTION

Fixes ISSUE #957 .

### Motivation

- In cloud-native application scenarios, the flow of events is very complex and common, event tracking is very meaningful and important for analyzing problems



### Modifications

- Add trace buried point for http protocol in eventmesh-runtime
- Record specific attributes to the trace, for example, the time of the event life cycle, the eventmesh ip that the event passed through


