### PR TITLE
Fix Error when Running/Debugging the Application on Linux Platform

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/config/ConfigurationWrapper.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/config/ConfigurationWrapper.java
@@ -61,9 +61,13 @@ public class ConfigurationWrapper {
     };
 
     public ConfigurationWrapper(String directoryPath, String fileName, boolean reload) {
-        this.directoryPath = directoryPath;
+        this.directoryPath = directoryPath
+                .replace('/', File.separator.charAt(0))
+                .replace('\\', File.separator.charAt(0));
         this.fileName = fileName;
-        this.file = directoryPath + File.separator + fileName;
+        this.file = (directoryPath + File.separator + fileName)
+                .replace('/', File.separator.charAt(0))
+                .replace('\\', File.separator.charAt(0));
         this.reload = reload;
         init();
     }

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/http/demo/sub/controller/SubController.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/http/demo/sub/controller/SubController.java
@@ -70,9 +70,4 @@ public class SubController {
         return JsonUtils.serialize(map);
     }
 
-    @RequestMapping("/")
-    public String test() {
-        return "Greetings from Spring Boot!";
-    }
-
 }

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/http/demo/sub/controller/SubController.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/http/demo/sub/controller/SubController.java
@@ -70,4 +70,9 @@ public class SubController {
         return JsonUtils.serialize(map);
     }
 
+    @RequestMapping("/")
+    public String test() {
+        return "Greetings from Spring Boot!";
+    }
+
 }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes ISSUE #<XXX>`.)
-->

### Motivation

When the Eventmesh application runs on a Linux Platform using IDE, there will be errors on reading the properties and setting files. The error was due to the mix-use of forward-slash and backward-slash. The bug impacts developers who use IDE on Mac or Linux Platform

### Modifications

Replace all the / and \ with proper file separators that work both for Linux and Windows


### Documentation

- Does this pull request introduce a new feature? (yes / no)
- No
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- No new feature introduced
