### PR TITLE
[ISSUE #987] try-with-resource to close the BufferedReader

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/config/ConfigurationWrapper.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/config/ConfigurationWrapper.java
@@ -80,9 +80,9 @@ public class ConfigurationWrapper {
     }
 
     private void load() {
-        try {
+        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
             logger.info("loading config: {}", file);
-            properties.load(new BufferedReader(new FileReader(file)));
+            properties.load(reader);
         } catch (IOException e) {
             logger.error("loading properties [{}] error", file, e);
         }


### PR DESCRIPTION
Fixes ISSUE #987.

### Motivation



### Modifications

use try-with-resource to close the BufferedReader.



### Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
