### PR TITLE
[ISSUE #995] Add parameter checking before sending message for EventMeshMessageTCPClient .

### DIFF
--- a/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/impl/eventmeshmessage/EventMeshMessageTCPClient.java
+++ b/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/impl/eventmeshmessage/EventMeshMessageTCPClient.java
@@ -17,6 +17,7 @@
 
 package org.apache.eventmesh.client.tcp.impl.eventmeshmessage;
 
+import com.google.common.base.Preconditions;
 import org.apache.eventmesh.client.tcp.EventMeshTCPClient;
 import org.apache.eventmesh.client.tcp.EventMeshTCPPubClient;
 import org.apache.eventmesh.client.tcp.EventMeshTCPSubClient;
@@ -28,6 +29,8 @@ import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.SubscriptionType;
 import org.apache.eventmesh.common.protocol.tcp.EventMeshMessage;
 import org.apache.eventmesh.common.protocol.tcp.Package;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class EventMeshMessageTCPClient implements EventMeshTCPClient<EventMeshMessage> {
 
@@ -47,22 +50,26 @@ public class EventMeshMessageTCPClient implements EventMeshTCPClient<EventMeshMe
 
     @Override
     public Package rr(EventMeshMessage eventMeshMessage, long timeout) throws EventMeshException {
+        validateMessage(eventMeshMessage);
         return eventMeshMessageTCPPubClient.rr(eventMeshMessage, timeout);
     }
 
     @Override
     public void asyncRR(EventMeshMessage eventMeshMessage, AsyncRRCallback callback, long timeout)
             throws EventMeshException {
+        validateMessage(eventMeshMessage);
         eventMeshMessageTCPPubClient.asyncRR(eventMeshMessage, callback, timeout);
     }
 
     @Override
     public Package publish(EventMeshMessage eventMeshMessage, long timeout) throws EventMeshException {
+        validateMessage(eventMeshMessage);
         return eventMeshMessageTCPPubClient.publish(eventMeshMessage, timeout);
     }
 
     @Override
     public void broadcast(EventMeshMessage eventMeshMessage, long timeout) throws EventMeshException {
+        validateMessage(eventMeshMessage);
         eventMeshMessageTCPPubClient.broadcast(eventMeshMessage, timeout);
     }
 
@@ -108,5 +115,11 @@ public class EventMeshMessageTCPClient implements EventMeshTCPClient<EventMeshMe
     @Override
     public EventMeshTCPSubClient<EventMeshMessage> getSubClient() {
         return eventMeshMessageTCPSubClient;
+    }
+
+    private void validateMessage(EventMeshMessage message) {
+        Preconditions.checkNotNull(message, "Message cannot be null");
+        Preconditions.checkArgument(isNotBlank(message.getTopic()), "Message's topic cannot be null and blank");
+        Preconditions.checkArgument(isNotBlank(message.getBody()), "Message's body cannot be null and blank");
     }
 }

--- a/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/impl/eventmeshmessage/EventMeshMessageTCPClient.java
+++ b/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/impl/eventmeshmessage/EventMeshMessageTCPClient.java
@@ -17,6 +17,8 @@
 
 package org.apache.eventmesh.client.tcp.impl.eventmeshmessage;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 import org.apache.eventmesh.client.tcp.EventMeshTCPClient;
 import org.apache.eventmesh.client.tcp.EventMeshTCPPubClient;
 import org.apache.eventmesh.client.tcp.EventMeshTCPSubClient;
@@ -30,8 +32,6 @@ import org.apache.eventmesh.common.protocol.tcp.EventMeshMessage;
 import org.apache.eventmesh.common.protocol.tcp.Package;
 
 import com.google.common.base.Preconditions;
-
-import org.apache.commons.lang3.StringUtils;
 
 public class EventMeshMessageTCPClient implements EventMeshTCPClient<EventMeshMessage> {
 
@@ -120,7 +120,7 @@ public class EventMeshMessageTCPClient implements EventMeshTCPClient<EventMeshMe
 
     private void validateMessage(EventMeshMessage message) {
         Preconditions.checkNotNull(message, "Message cannot be null");
-        Preconditions.checkArgument(StringUtils.isNotBlank(message.getTopic()), "Message's topic cannot be null and blank");
-        Preconditions.checkArgument(StringUtils.isNotBlank(message.getBody()), "Message's body cannot be null and blank");
+        Preconditions.checkArgument(isNotBlank(message.getTopic()), "Message's topic cannot be null and blank");
+        Preconditions.checkArgument(isNotBlank(message.getBody()), "Message's body cannot be null and blank");
     }
 }

--- a/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/impl/eventmeshmessage/EventMeshMessageTCPClient.java
+++ b/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/impl/eventmeshmessage/EventMeshMessageTCPClient.java
@@ -17,7 +17,6 @@
 
 package org.apache.eventmesh.client.tcp.impl.eventmeshmessage;
 
-import com.google.common.base.Preconditions;
 import org.apache.eventmesh.client.tcp.EventMeshTCPClient;
 import org.apache.eventmesh.client.tcp.EventMeshTCPPubClient;
 import org.apache.eventmesh.client.tcp.EventMeshTCPSubClient;
@@ -30,7 +29,9 @@ import org.apache.eventmesh.common.protocol.SubscriptionType;
 import org.apache.eventmesh.common.protocol.tcp.EventMeshMessage;
 import org.apache.eventmesh.common.protocol.tcp.Package;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import com.google.common.base.Preconditions;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class EventMeshMessageTCPClient implements EventMeshTCPClient<EventMeshMessage> {
 
@@ -119,7 +120,7 @@ public class EventMeshMessageTCPClient implements EventMeshTCPClient<EventMeshMe
 
     private void validateMessage(EventMeshMessage message) {
         Preconditions.checkNotNull(message, "Message cannot be null");
-        Preconditions.checkArgument(isNotBlank(message.getTopic()), "Message's topic cannot be null and blank");
-        Preconditions.checkArgument(isNotBlank(message.getBody()), "Message's body cannot be null and blank");
+        Preconditions.checkArgument(StringUtils.isNotBlank(message.getTopic()), "Message's topic cannot be null and blank");
+        Preconditions.checkArgument(StringUtils.isNotBlank(message.getBody()), "Message's body cannot be null and blank");
     }
 }


### PR DESCRIPTION
Fixes ISSUE #995 .

### Motivation
None.

### Modifications

- Add `EventMeshMessageTCPClient#validateMessage` method in `EventMeshMessageTCPClient` .

### Documentation
None.