### PR TITLE
[ISSUE #1021]Fix the case that span is null

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/trace/Trace.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/trace/Trace.java
@@ -36,7 +36,7 @@ import io.opentelemetry.context.Context;
 public class Trace {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    private boolean useTrace = false;
+    private final boolean useTrace;
     private EventMeshTraceService eventMeshTraceService;
 
     public Trace(boolean useTrace) {
@@ -53,7 +53,7 @@ public class Trace {
     public Span createSpan(String spanName, SpanKind spanKind, long startTime, TimeUnit timeUnit,
                            Context context, boolean isSpanFinishInOtherThread) {
         if (!useTrace) {
-            return null;
+            return Span.getInvalid();
         }
         return eventMeshTraceService.createSpan(spanName, spanKind, startTime, timeUnit, context,
             isSpanFinishInOtherThread);
@@ -62,7 +62,7 @@ public class Trace {
     public Span createSpan(String spanName, SpanKind spanKind, Context context,
                            boolean isSpanFinishInOtherThread) {
         if (!useTrace) {
-            return null;
+            return Span.getInvalid();
         }
         return eventMeshTraceService.createSpan(spanName, spanKind, context,
             isSpanFinishInOtherThread);


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes ISSUE #<XXX>`.)
-->

Fixed ISSUE #1021 

### Motivation

When I run the `eventmesh-runtime` in debug model. I find a bug which is NullpointException at line 432 in file `ClientGroupWrapper ` . So I want to  Fix it.



### Modifications

I read some information about the telemetry. I think the method `createSpan` in file `Trace` should not return `null`, at least return a invalid Span .


### Documentation

- Does this pull request introduce a new feature? 
- no
