### PR TITLE
[ISSUE #790] [Bug] Method invokes System.exit(0)

### DIFF
--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/app/service/SubService.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/app/service/SubService.java
@@ -90,7 +90,7 @@ public class SubService implements InitializingBean {
                 e.printStackTrace();
             }
             logger.info("stopThread start....");
-            System.exit(0);
+            throw new RuntimeException();
         });
         stopThread.start();
     }

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/http/demo/sub/service/SubService.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/http/demo/sub/service/SubService.java
@@ -93,7 +93,7 @@ public class SubService implements InitializingBean {
                 e.printStackTrace();
             }
             logger.info("stopThread start....");
-            System.exit(0);
+            throw new RuntimeException();
         });
         stopThread.start();
     }


### PR DESCRIPTION
replace `System.exit(0) ` with `throw new RuntimeException();`
Fixes ISSUE #988 .
