### PR TITLE
[ISSUE #1047] fix send response twice in eventmesh http server

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/AbstractHTTPServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/AbstractHTTPServer.java
@@ -466,18 +466,6 @@ public abstract class AbstractHTTPServer extends AbstractRemotingServer {
                         }
 
                         processor.processRequest(ctx, asyncContext);
-                        if (!asyncContext.isComplete()) {
-                            return;
-                        }
-
-                        metrics.getSummaryMetrics()
-                            .recordHTTPReqResTimeCost(System.currentTimeMillis() - requestWrapper.getReqTime());
-
-                        if (httpLogger.isDebugEnabled()) {
-                            httpLogger.debug("{}", asyncContext.getResponse());
-                        }
-
-                        sendResponse(ctx, asyncContext.getResponse().httpResponse());
                     } catch (Exception e) {
                         httpServerLogger.error("process error", e);
                     }
@@ -524,19 +512,6 @@ public abstract class AbstractHTTPServer extends AbstractRemotingServer {
                         }
 
                         processor.processRequest(ctx, asyncContext);
-                        if (!asyncContext.isComplete()) {
-                            return;
-                        }
-
-                        metrics.getSummaryMetrics()
-                            .recordHTTPReqResTimeCost(System.currentTimeMillis() - request.getReqTime());
-
-                        if (httpLogger.isDebugEnabled()) {
-                            httpLogger.debug("{}", asyncContext.getResponse());
-                        }
-
-                        sendResponse(ctx, asyncContext.getResponse().httpResponse());
-
                     } catch (Exception e) {
                         httpServerLogger.error("process error", e);
                     }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/AdminShutdownProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/AdminShutdownProcessor.java
@@ -25,6 +25,7 @@ import org.apache.eventmesh.runtime.boot.EventMeshServer;
 import org.apache.eventmesh.runtime.constants.EventMeshConstants;
 import org.apache.eventmesh.runtime.core.protocol.http.async.AsyncContext;
 import org.apache.eventmesh.runtime.core.protocol.http.processor.inf.HttpRequestProcessor;
+import org.apache.eventmesh.runtime.util.EventMeshUtil;
 import org.apache.eventmesh.runtime.util.RemotingHelper;
 
 import org.slf4j.Logger;
@@ -54,7 +55,7 @@ public class AdminShutdownProcessor implements HttpRequestProcessor {
         eventMeshServer.shutdown();
 
         responseEventMeshCommand = asyncContext.getRequest().createHttpCommandResponse(EventMeshRetCode.SUCCESS);
-        asyncContext.onComplete(responseEventMeshCommand);
+        EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshServer.getEventMeshHTTPServer());
     }
 
     @Override

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/BatchSendMessageProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/BatchSendMessageProcessor.java
@@ -41,6 +41,7 @@ import org.apache.eventmesh.runtime.core.protocol.http.async.AsyncContext;
 import org.apache.eventmesh.runtime.core.protocol.http.processor.inf.HttpRequestProcessor;
 import org.apache.eventmesh.runtime.core.protocol.http.producer.EventMeshProducer;
 import org.apache.eventmesh.runtime.core.protocol.http.producer.SendMessageContext;
+import org.apache.eventmesh.runtime.util.EventMeshUtil;
 import org.apache.eventmesh.runtime.util.RemotingHelper;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -104,7 +105,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
                     sendMessageBatchResponseHeader,
                     SendMessageBatchResponseBody.buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode(),
                             EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -120,7 +121,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
                 sendMessageBatchResponseHeader,
                 SendMessageBatchResponseBody.buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode(),
                     "Event batch size exceeds the limit: " + eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshEventBatchSize));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -135,7 +136,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
                         sendMessageBatchResponseHeader,
                         SendMessageBatchResponseBody.buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getRetCode(),
                                 EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getErrMsg()));
-                asyncContext.onComplete(responseEventMeshCommand);
+                EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
                 return;
             }
 
@@ -148,7 +149,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
                     sendMessageBatchResponseHeader,
                     SendMessageBatchResponseBody.buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getRetCode(),
                         "Event size exceeds the limit: " + eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshEventSize));
-                asyncContext.onComplete(responseEventMeshCommand);
+                EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
                 return;
             }
 
@@ -165,7 +166,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
                         sendMessageBatchResponseHeader,
                         SendMessageBatchResponseBody.buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getRetCode(),
                                 EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getErrMsg()));
-                asyncContext.onComplete(responseEventMeshCommand);
+                EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
                 return;
             }
 
@@ -183,7 +184,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
                         sendMessageBatchResponseHeader,
                         SendMessageBatchResponseBody.buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode(),
                                 EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getErrMsg()));
-                asyncContext.onComplete(responseEventMeshCommand);
+                EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
                 return;
             }
 
@@ -196,7 +197,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
                 SendMessageBatchResponseBody.buildBody(EventMeshRetCode.EVENTMESH_BATCH_SPEED_OVER_LIMIT_ERR.getRetCode(),
                     EventMeshRetCode.EVENTMESH_BATCH_SPEED_OVER_LIMIT_ERR.getErrMsg()));
             eventMeshHTTPServer.metrics.getSummaryMetrics().recordSendBatchMsgDiscard(eventSize);
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -209,7 +210,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
                     sendMessageBatchResponseHeader,
                     SendMessageBatchResponseBody.buildBody(EventMeshRetCode.EVENTMESH_BATCH_PRODUCER_STOPED_ERR.getRetCode(),
                             EventMeshRetCode.EVENTMESH_BATCH_PRODUCER_STOPED_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -240,7 +241,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
                     responseEventMeshCommand = asyncContext.getRequest().createHttpCommandResponse(
                             sendMessageBatchResponseHeader,
                             SendMessageResponseBody.buildBody(EventMeshRetCode.EVENTMESH_ACL_ERR.getRetCode(), e.getMessage()));
-                    asyncContext.onComplete(responseEventMeshCommand);
+                    EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
                     aclLogger.warn("CLIENT HAS NO PERMISSION,BatchSendMessageProcessor send failed", e);
                     return;
                 }
@@ -278,7 +279,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
                     sendMessageBatchResponseHeader,
                     SendMessageBatchResponseBody.buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode(),
                             EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -347,7 +348,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
                 sendMessageBatchResponseHeader,
                 SendMessageBatchResponseBody.buildBody(EventMeshRetCode.SUCCESS.getRetCode(),
                         EventMeshRetCode.SUCCESS.getErrMsg()));
-        asyncContext.onComplete(responseEventMeshCommand);
+        EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
 
         return;
     }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/BatchSendMessageV2Processor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/BatchSendMessageV2Processor.java
@@ -113,7 +113,7 @@ public class BatchSendMessageV2Processor implements HttpRequestProcessor {
                     SendMessageBatchV2ResponseBody
                             .buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getRetCode(),
                                     EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -134,7 +134,7 @@ public class BatchSendMessageV2Processor implements HttpRequestProcessor {
                     SendMessageBatchV2ResponseBody
                             .buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getRetCode(),
                                     EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -155,7 +155,7 @@ public class BatchSendMessageV2Processor implements HttpRequestProcessor {
                     SendMessageBatchV2ResponseBody
                             .buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode(),
                                     EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -168,7 +168,7 @@ public class BatchSendMessageV2Processor implements HttpRequestProcessor {
                 sendMessageBatchV2ResponseHeader,
                 SendMessageBatchV2ResponseBody.buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode(),
                     "Event size exceeds the limit: " + eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshEventSize));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -188,7 +188,7 @@ public class BatchSendMessageV2Processor implements HttpRequestProcessor {
                         SendMessageResponseBody
                                 .buildBody(EventMeshRetCode.EVENTMESH_ACL_ERR.getRetCode(),
                                         e.getMessage()));
-                asyncContext.onComplete(responseEventMeshCommand);
+                EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
                 aclLogger
                         .warn("CLIENT HAS NO PERMISSION,BatchSendMessageV2Processor send failed", e);
                 return;
@@ -204,7 +204,7 @@ public class BatchSendMessageV2Processor implements HttpRequestProcessor {
                     .buildBody(EventMeshRetCode.EVENTMESH_BATCH_SPEED_OVER_LIMIT_ERR.getRetCode(),
                         EventMeshRetCode.EVENTMESH_BATCH_SPEED_OVER_LIMIT_ERR.getErrMsg()));
             eventMeshHTTPServer.metrics.getSummaryMetrics().recordSendBatchMsgDiscard(1);
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -217,7 +217,7 @@ public class BatchSendMessageV2Processor implements HttpRequestProcessor {
                     SendMessageBatchV2ResponseBody
                             .buildBody(EventMeshRetCode.EVENTMESH_BATCH_PRODUCER_STOPED_ERR.getRetCode(),
                                     EventMeshRetCode.EVENTMESH_BATCH_PRODUCER_STOPED_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -253,7 +253,7 @@ public class BatchSendMessageV2Processor implements HttpRequestProcessor {
                                     EventMeshRetCode.EVENTMESH_PACKAGE_MSG_ERR.getErrMsg()
                                             +
                                             EventMeshUtil.stackTrace(e, 2)));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -292,7 +292,7 @@ public class BatchSendMessageV2Processor implements HttpRequestProcessor {
                                     EventMeshRetCode.EVENTMESH_SEND_BATCHLOG_MSG_ERR.getErrMsg()
                                             +
                                             EventMeshUtil.stackTrace(e, 2)));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             long batchEndTime = System.currentTimeMillis();
             eventMeshHTTPServer.getHttpRetryer().pushRetry(sendMessageContext.delay(10000));
             eventMeshHTTPServer.metrics.getSummaryMetrics().recordBatchSendMsgCost(batchEndTime - batchStartTime);
@@ -305,7 +305,7 @@ public class BatchSendMessageV2Processor implements HttpRequestProcessor {
                 sendMessageBatchV2ResponseHeader,
                 SendMessageBatchV2ResponseBody.buildBody(EventMeshRetCode.SUCCESS.getRetCode(),
                         EventMeshRetCode.SUCCESS.getErrMsg()));
-        asyncContext.onComplete(responseEventMeshCommand);
+        EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
 
     }
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/HeartBeatProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/HeartBeatProcessor.java
@@ -88,7 +88,7 @@ public class HeartBeatProcessor implements HttpRequestProcessor {
                     heartbeatResponseHeader,
                     HeartbeatResponseBody.buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getRetCode(),
                             EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -101,7 +101,7 @@ public class HeartBeatProcessor implements HttpRequestProcessor {
                     heartbeatResponseHeader,
                     HeartbeatResponseBody.buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode(),
                             EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
         ConcurrentHashMap<String, List<Client>> tmp = new ConcurrentHashMap<>();
@@ -143,7 +143,7 @@ public class HeartBeatProcessor implements HttpRequestProcessor {
                             heartbeatResponseHeader,
                             SendMessageResponseBody
                                     .buildBody(EventMeshRetCode.EVENTMESH_ACL_ERR.getRetCode(), e.getMessage()));
-                    asyncContext.onComplete(responseEventMeshCommand);
+                    EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
                     aclLogger.warn("CLIENT HAS NO PERMISSION,HeartBeatProcessor subscribe failed", e);
                     return;
                 }
@@ -201,11 +201,11 @@ public class HeartBeatProcessor implements HttpRequestProcessor {
             responseEventMeshCommand = asyncContext.getRequest().createHttpCommandResponse(EventMeshRetCode.SUCCESS);
             asyncContext.onComplete(responseEventMeshCommand, handler);
         } catch (Exception e) {
-            HttpCommand err = asyncContext.getRequest().createHttpCommandResponse(
+            responseEventMeshCommand = asyncContext.getRequest().createHttpCommandResponse(
                     heartbeatResponseHeader,
                     HeartbeatResponseBody.buildBody(EventMeshRetCode.EVENTMESH_HEARTBEAT_ERR.getRetCode(),
                             EventMeshRetCode.EVENTMESH_HEARTBEAT_ERR.getErrMsg() + EventMeshUtil.stackTrace(e, 2)));
-            asyncContext.onComplete(err);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             long endTime = System.currentTimeMillis();
             httpLogger.error("message|eventMesh2mq|REQ|ASYNC|heartBeatMessageCost={}ms",
                     endTime - startTime, e);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalSubscribeEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalSubscribeEventProcessor.java
@@ -108,7 +108,7 @@ public class LocalSubscribeEventProcessor extends AbstractEventProcessor {
             responseBodyMap.put("retCode", EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getRetCode());
             responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getErrMsg());
             responseWrapper = requestWrapper.createHttpResponse(responseHeaderMap, responseBodyMap);
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -125,7 +125,7 @@ public class LocalSubscribeEventProcessor extends AbstractEventProcessor {
             responseBodyMap.put("retCode", EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode());
             responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getErrMsg());
             responseWrapper = requestWrapper.createHttpResponse(responseHeaderMap, responseBodyMap);
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -154,7 +154,7 @@ public class LocalSubscribeEventProcessor extends AbstractEventProcessor {
                     responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_ACL_ERR.getErrMsg());
 
                     responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
-                    asyncContext.onComplete(responseWrapper);
+                    EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
                     aclLogger.warn("CLIENT HAS NO PERMISSION,SubscribeProcessor subscribe failed", e);
                     return;
                 }
@@ -170,7 +170,7 @@ public class LocalSubscribeEventProcessor extends AbstractEventProcessor {
                 responseBodyMap.put("retCode", EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode());
                 responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getErrMsg() + " invalid URL: " + url);
                 responseWrapper = requestWrapper.createHttpResponse(responseHeaderMap, responseBodyMap);
-                asyncContext.onComplete(responseWrapper);
+                EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
                 return;
             }
         } catch (Exception e) {
@@ -179,7 +179,7 @@ public class LocalSubscribeEventProcessor extends AbstractEventProcessor {
             responseBodyMap.put("retCode", EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode());
             responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getErrMsg() + " invalid URL: " + url);
             responseWrapper = requestWrapper.createHttpResponse(responseHeaderMap, responseBodyMap);
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -193,7 +193,7 @@ public class LocalSubscribeEventProcessor extends AbstractEventProcessor {
             responseBodyMap.put("retCode", EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode());
             responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getErrMsg() + "unauthorized webhook URL: " + url);
             responseWrapper = requestWrapper.createHttpResponse(responseHeaderMap, responseBodyMap);
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -293,9 +293,8 @@ public class LocalSubscribeEventProcessor extends AbstractEventProcessor {
                 Map<String, Object> responseBodyMap = new HashMap<>();
                 responseBodyMap.put("retCode", EventMeshRetCode.EVENTMESH_SUBSCRIBE_ERR.getRetCode());
                 responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_SUBSCRIBE_ERR.getErrMsg() + EventMeshUtil.stackTrace(e, 2));
-                HttpEventWrapper err = asyncContext.getRequest().createHttpResponse(
-                    responseHeaderMap, responseBodyMap);
-                asyncContext.onComplete(err);
+                responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
+                EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
                 long endTime = System.currentTimeMillis();
                 httpLogger.error(
                     "message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}"

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalUnSubscribeEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalUnSubscribeEventProcessor.java
@@ -102,7 +102,7 @@ public class LocalUnSubscribeEventProcessor extends AbstractEventProcessor {
             responseBodyMap.put("retCode", EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getRetCode());
             responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getErrMsg());
             responseWrapper = requestWrapper.createHttpResponse(responseHeaderMap, responseBodyMap);
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -117,7 +117,7 @@ public class LocalUnSubscribeEventProcessor extends AbstractEventProcessor {
             responseBodyMap.put("retCode", EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode());
             responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getErrMsg());
             responseWrapper = requestWrapper.createHttpResponse(responseHeaderMap, responseBodyMap);
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -227,8 +227,8 @@ public class LocalUnSubscribeEventProcessor extends AbstractEventProcessor {
                     Map<String, Object> responseBodyMap = new HashMap<>();
                     responseBodyMap.put("retCode", EventMeshRetCode.EVENTMESH_UNSUBSCRIBE_ERR.getRetCode());
                     responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_UNSUBSCRIBE_ERR.getErrMsg() + EventMeshUtil.stackTrace(e, 2));
-                    HttpEventWrapper err = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
-                    asyncContext.onComplete(err);
+                    responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
+                    EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
                     long endTime = System.currentTimeMillis();
                     httpLogger.error(
                         "message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms"
@@ -256,9 +256,8 @@ public class LocalUnSubscribeEventProcessor extends AbstractEventProcessor {
                     Map<String, Object> responseBodyMap = new HashMap<>();
                     responseBodyMap.put("retCode", EventMeshRetCode.EVENTMESH_UNSUBSCRIBE_ERR.getRetCode());
                     responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_UNSUBSCRIBE_ERR.getErrMsg() + EventMeshUtil.stackTrace(e, 2));
-                    HttpEventWrapper err = asyncContext.getRequest().createHttpResponse(
-                        responseHeaderMap, responseBodyMap);
-                    asyncContext.onComplete(err);
+                    responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
+                    EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
                     long endTime = System.currentTimeMillis();
                     httpLogger.error(
                         "message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms"

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/RemoteUnSubscribeEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/RemoteUnSubscribeEventProcessor.java
@@ -109,7 +109,7 @@ public class RemoteUnSubscribeEventProcessor extends AbstractEventProcessor {
             responseBodyMap.put("retCode", EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getRetCode());
             responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getErrMsg());
             responseWrapper = requestWrapper.createHttpResponse(responseHeaderMap, responseBodyMap);
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -126,7 +126,7 @@ public class RemoteUnSubscribeEventProcessor extends AbstractEventProcessor {
             responseBodyMap.put("retCode", EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode());
             responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getErrMsg());
             responseWrapper = requestWrapper.createHttpResponse(responseHeaderMap, responseBodyMap);
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -209,22 +209,20 @@ public class RemoteUnSubscribeEventProcessor extends AbstractEventProcessor {
                 Map<String, Object> responseBodyMap = new HashMap<>();
                 responseBodyMap.put("retCode", EventMeshRetCode.EVENTMESH_UNSUBSCRIBE_ERR.getRetCode());
                 responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_UNSUBSCRIBE_ERR.getErrMsg());
-                HttpEventWrapper err = asyncContext.getRequest().createHttpResponse(
-                    responseHeaderMap, responseBodyMap);
-                asyncContext.onComplete(err);
+                responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
+                EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             }
 
         } catch (Exception e) {
             Map<String, Object> responseBodyMap = new HashMap<>();
             responseBodyMap.put("retCode", EventMeshRetCode.EVENTMESH_UNSUBSCRIBE_ERR.getRetCode());
             responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_UNSUBSCRIBE_ERR.getErrMsg() + EventMeshUtil.stackTrace(e, 2));
-            HttpEventWrapper err = asyncContext.getRequest().createHttpResponse(
-                responseHeaderMap, responseBodyMap);
-            asyncContext.onComplete(err);
+            responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             long endTime = System.currentTimeMillis();
             httpLogger.error(
                 "message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}"
-                    + "|bizSeqNo={}|uniqueId={}", endTime - startTime,
+                    + "|url={}", endTime - startTime,
                 topic, unSubscribeUrl, e);
             eventMeshHTTPServer.metrics.getSummaryMetrics().recordSendMsgFailed();
             eventMeshHTTPServer.metrics.getSummaryMetrics().recordSendMsgCost(endTime - startTime);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/ReplyMessageProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/ReplyMessageProcessor.java
@@ -103,7 +103,7 @@ public class ReplyMessageProcessor implements HttpRequestProcessor {
                     replyMessageResponseHeader,
                     ReplyMessageResponseBody.buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getRetCode(),
                             EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -120,7 +120,7 @@ public class ReplyMessageProcessor implements HttpRequestProcessor {
                     replyMessageResponseHeader,
                     ReplyMessageResponseBody.buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getRetCode(),
                             EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -137,7 +137,7 @@ public class ReplyMessageProcessor implements HttpRequestProcessor {
                     replyMessageResponseHeader,
                     ReplyMessageResponseBody.buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode(),
                             EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -149,7 +149,7 @@ public class ReplyMessageProcessor implements HttpRequestProcessor {
                 ReplyMessageResponseBody.buildBody(EventMeshRetCode.EVENTMESH_HTTP_MES_SEND_OVER_LIMIT_ERR.getRetCode(),
                     EventMeshRetCode.EVENTMESH_HTTP_MES_SEND_OVER_LIMIT_ERR.getErrMsg()));
             eventMeshHTTPServer.metrics.getSummaryMetrics().recordHTTPDiscard();
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -162,7 +162,7 @@ public class ReplyMessageProcessor implements HttpRequestProcessor {
                 replyMessageResponseHeader,
                 ReplyMessageResponseBody.buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode(),
                     "Event size exceeds the limit: " + eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshEventSize));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -173,7 +173,7 @@ public class ReplyMessageProcessor implements HttpRequestProcessor {
                     replyMessageResponseHeader,
                     ReplyMessageResponseBody.buildBody(EventMeshRetCode.EVENTMESH_GROUP_PRODUCER_STOPED_ERR.getRetCode(),
                             EventMeshRetCode.EVENTMESH_GROUP_PRODUCER_STOPED_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -184,14 +184,14 @@ public class ReplyMessageProcessor implements HttpRequestProcessor {
         String origTopic = event.getSubject();
 
         final String replyMQCluster = event.getExtension(EventMeshConstants.PROPERTY_MESSAGE_CLUSTER).toString();
-        if (!org.apache.commons.lang3.StringUtils.isEmpty(replyMQCluster)) {
+        if (!StringUtils.isEmpty(replyMQCluster)) {
             replyTopic = replyMQCluster + "-" + replyTopic;
         } else {
             responseEventMeshCommand = asyncContext.getRequest().createHttpCommandResponse(
                     replyMessageResponseHeader,
                     ReplyMessageResponseBody.buildBody(EventMeshRetCode.EVENTMESH_REPLY_MSG_ERR.getRetCode(),
                             EventMeshRetCode.EVENTMESH_REPLY_MSG_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -215,7 +215,7 @@ public class ReplyMessageProcessor implements HttpRequestProcessor {
                 replyMessageResponseHeader,
                 ReplyMessageResponseBody.buildBody(EventMeshRetCode.EVENTMESH_PACKAGE_MSG_ERR.getRetCode(),
                     EventMeshRetCode.EVENTMESH_PACKAGE_MSG_ERR.getErrMsg() + EventMeshUtil.stackTrace(e, 2)));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -272,11 +272,11 @@ public class ReplyMessageProcessor implements HttpRequestProcessor {
                 }
             });
         } catch (Exception ex) {
-            HttpCommand err = asyncContext.getRequest().createHttpCommandResponse(
+            responseEventMeshCommand = asyncContext.getRequest().createHttpCommandResponse(
                 replyMessageResponseHeader,
                 SendMessageResponseBody.buildBody(EventMeshRetCode.EVENTMESH_REPLY_MSG_ERR.getRetCode(),
                     EventMeshRetCode.EVENTMESH_REPLY_MSG_ERR.getErrMsg() + EventMeshUtil.stackTrace(ex, 2)));
-            asyncContext.onComplete(err);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             long endTime = System.currentTimeMillis();
             messageLogger.error("message|eventMesh2mq|RSP|SYNC|reply2MQCost={}|topic={}|origTopic={}|bizSeqNo={}|uniqueId={}",
                 endTime - startTime, replyTopic, origTopic, bizNo, uniqueId, ex);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendAsyncEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendAsyncEventProcessor.java
@@ -131,7 +131,7 @@ public class SendAsyncEventProcessor implements EventProcessor {
             responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getErrMsg());
 
             responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -149,7 +149,7 @@ public class SendAsyncEventProcessor implements EventProcessor {
             responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getErrMsg());
 
             responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -168,7 +168,7 @@ public class SendAsyncEventProcessor implements EventProcessor {
 
             responseWrapper = asyncContext.getRequest().createHttpResponse(
                 responseHeaderMap, responseBodyMap);
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -187,7 +187,7 @@ public class SendAsyncEventProcessor implements EventProcessor {
                 responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_ACL_ERR.getErrMsg());
 
                 responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
-                asyncContext.onComplete(responseWrapper);
+                EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
                 aclLogger.warn("CLIENT HAS NO PERMISSION,SendAsyncMessageProcessor send failed", e);
                 return;
             }
@@ -201,7 +201,7 @@ public class SendAsyncEventProcessor implements EventProcessor {
 
             responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
             eventMeshHTTPServer.metrics.getSummaryMetrics().recordHTTPDiscard();
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -211,7 +211,7 @@ public class SendAsyncEventProcessor implements EventProcessor {
             responseBodyMap.put("retCode", EventMeshRetCode.EVENTMESH_GROUP_PRODUCER_STOPED_ERR.getRetCode());
             responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_GROUP_PRODUCER_STOPED_ERR.getErrMsg());
             responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -223,7 +223,7 @@ public class SendAsyncEventProcessor implements EventProcessor {
             responseBodyMap.put("retCode", EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode());
             responseBodyMap.put("retMsg", "Event size exceeds the limit: " + eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshEventSize);
             responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -243,7 +243,7 @@ public class SendAsyncEventProcessor implements EventProcessor {
             responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_PACKAGE_MSG_ERR.getErrMsg() + EventMeshUtil.stackTrace(e, 2));
             responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
 
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -307,8 +307,8 @@ public class SendAsyncEventProcessor implements EventProcessor {
         } catch (Exception ex) {
             responseBodyMap.put("retCode", EventMeshRetCode.EVENTMESH_SEND_ASYNC_MSG_ERR.getRetCode());
             responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_SEND_ASYNC_MSG_ERR.getErrMsg() + EventMeshUtil.stackTrace(ex, 2));
-            HttpEventWrapper err = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
-            asyncContext.onComplete(err);
+            responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
 
             eventMeshHTTPServer.getHttpRetryer().pushRetry(sendMessageContext.delay(10000));
             long endTime = System.currentTimeMillis();

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendAsyncMessageProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendAsyncMessageProcessor.java
@@ -112,7 +112,7 @@ public class SendAsyncMessageProcessor implements HttpRequestProcessor {
                 sendMessageResponseHeader,
                 SendMessageResponseBody.buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getRetCode(),
                     EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
 
             Span excepSpan = TraceUtils.prepareServerSpan(EventMeshUtil.getCloudEventExtensionMap(protocolVersin, event),
                 EventMeshTraceConstants.TRACE_UPSTREAM_EVENTMESH_SERVER_SPAN, false);
@@ -134,7 +134,7 @@ public class SendAsyncMessageProcessor implements HttpRequestProcessor {
                 sendMessageResponseHeader,
                 SendMessageResponseBody.buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getRetCode(),
                     EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
 
             Span excepSpan = TraceUtils.prepareServerSpan(EventMeshUtil.getCloudEventExtensionMap(protocolVersin, event),
                 EventMeshTraceConstants.TRACE_UPSTREAM_EVENTMESH_SERVER_SPAN, false);
@@ -158,7 +158,7 @@ public class SendAsyncMessageProcessor implements HttpRequestProcessor {
                 sendMessageResponseHeader,
                 SendMessageResponseBody.buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode(),
                     EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
 
             Span excepSpan = TraceUtils.prepareServerSpan(EventMeshUtil.getCloudEventExtensionMap(protocolVersin, event),
                 EventMeshTraceConstants.TRACE_UPSTREAM_EVENTMESH_SERVER_SPAN, false);
@@ -182,7 +182,7 @@ public class SendAsyncMessageProcessor implements HttpRequestProcessor {
                 responseEventMeshCommand = asyncContext.getRequest().createHttpCommandResponse(
                     sendMessageResponseHeader,
                     SendMessageResponseBody.buildBody(EventMeshRetCode.EVENTMESH_ACL_ERR.getRetCode(), e.getMessage()));
-                asyncContext.onComplete(responseEventMeshCommand);
+                EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
                 aclLogger.warn("CLIENT HAS NO PERMISSION,SendAsyncMessageProcessor send failed", e);
 
                 Span excepSpan = TraceUtils.prepareServerSpan(EventMeshUtil.getCloudEventExtensionMap(protocolVersin, event),
@@ -201,7 +201,7 @@ public class SendAsyncMessageProcessor implements HttpRequestProcessor {
                 SendMessageResponseBody.buildBody(EventMeshRetCode.EVENTMESH_HTTP_MES_SEND_OVER_LIMIT_ERR.getRetCode(),
                     EventMeshRetCode.EVENTMESH_HTTP_MES_SEND_OVER_LIMIT_ERR.getErrMsg()));
             eventMeshHTTPServer.metrics.getSummaryMetrics().recordHTTPDiscard();
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
 
             Span excepSpan = TraceUtils.prepareServerSpan(EventMeshUtil.getCloudEventExtensionMap(protocolVersin, event),
                 EventMeshTraceConstants.TRACE_UPSTREAM_EVENTMESH_SERVER_SPAN, false);
@@ -217,7 +217,7 @@ public class SendAsyncMessageProcessor implements HttpRequestProcessor {
                 sendMessageResponseHeader,
                 SendMessageResponseBody.buildBody(EventMeshRetCode.EVENTMESH_GROUP_PRODUCER_STOPED_ERR.getRetCode(),
                     EventMeshRetCode.EVENTMESH_GROUP_PRODUCER_STOPED_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
 
             Span excepSpan = TraceUtils.prepareServerSpan(EventMeshUtil.getCloudEventExtensionMap(protocolVersin, event),
                 EventMeshTraceConstants.TRACE_UPSTREAM_EVENTMESH_SERVER_SPAN, false);
@@ -242,7 +242,7 @@ public class SendAsyncMessageProcessor implements HttpRequestProcessor {
                 sendMessageResponseHeader,
                 SendMessageResponseBody.buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode(),
                     "Event size exceeds the limit: " + eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshEventSize));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
 
             Span excepSpan = TraceUtils.prepareServerSpan(EventMeshUtil.getCloudEventExtensionMap(protocolVersin, event),
                 EventMeshTraceConstants.TRACE_UPSTREAM_EVENTMESH_SERVER_SPAN, false);
@@ -268,7 +268,7 @@ public class SendAsyncMessageProcessor implements HttpRequestProcessor {
                 sendMessageResponseHeader,
                 SendMessageResponseBody.buildBody(EventMeshRetCode.EVENTMESH_PACKAGE_MSG_ERR.getRetCode(),
                     EventMeshRetCode.EVENTMESH_PACKAGE_MSG_ERR.getErrMsg() + EventMeshUtil.stackTrace(e, 2)));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
 
             Span excepSpan = TraceUtils.prepareServerSpan(EventMeshUtil.getCloudEventExtensionMap(protocolVersin, event),
                 EventMeshTraceConstants.TRACE_UPSTREAM_EVENTMESH_SERVER_SPAN, false);
@@ -354,12 +354,12 @@ public class SendAsyncMessageProcessor implements HttpRequestProcessor {
 
 
         } catch (Exception ex) {
-            HttpCommand err = asyncContext.getRequest().createHttpCommandResponse(
+            responseEventMeshCommand = asyncContext.getRequest().createHttpCommandResponse(
                 sendMessageResponseHeader,
                 SendMessageResponseBody.buildBody(EventMeshRetCode.EVENTMESH_SEND_ASYNC_MSG_ERR.getRetCode(),
                     EventMeshRetCode.EVENTMESH_SEND_ASYNC_MSG_ERR.getErrMsg()
                         + EventMeshUtil.stackTrace(ex, 2)));
-            asyncContext.onComplete(err);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
 
             Span excepSpan = TraceUtils.prepareServerSpan(EventMeshUtil.getCloudEventExtensionMap(protocolVersin, event),
                 EventMeshTraceConstants.TRACE_UPSTREAM_EVENTMESH_SERVER_SPAN, false);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendAsyncRemoteEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendAsyncRemoteEventProcessor.java
@@ -28,7 +28,6 @@ import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.utils.IPUtils;
 import org.apache.eventmesh.common.utils.JsonUtils;
 import org.apache.eventmesh.common.utils.RandomStringUtils;
-import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.protocol.api.ProtocolAdaptor;
 import org.apache.eventmesh.protocol.api.ProtocolPluginFactory;
 import org.apache.eventmesh.runtime.acl.Acl;
@@ -161,7 +160,7 @@ public class SendAsyncRemoteEventProcessor implements EventProcessor {
             responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getErrMsg());
 
             responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -179,7 +178,7 @@ public class SendAsyncRemoteEventProcessor implements EventProcessor {
             responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getErrMsg());
 
             responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -198,7 +197,7 @@ public class SendAsyncRemoteEventProcessor implements EventProcessor {
 
             responseWrapper = asyncContext.getRequest().createHttpResponse(
                 responseHeaderMap, responseBodyMap);
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -217,7 +216,7 @@ public class SendAsyncRemoteEventProcessor implements EventProcessor {
                 responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_ACL_ERR.getErrMsg());
 
                 responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
-                asyncContext.onComplete(responseWrapper);
+                EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
                 aclLogger.warn("CLIENT HAS NO PERMISSION,SendAsyncMessageProcessor send failed", e);
                 return;
             }
@@ -231,7 +230,7 @@ public class SendAsyncRemoteEventProcessor implements EventProcessor {
 
             responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
             eventMeshHTTPServer.metrics.getSummaryMetrics().recordHTTPDiscard();
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -241,7 +240,7 @@ public class SendAsyncRemoteEventProcessor implements EventProcessor {
             responseBodyMap.put("retCode", EventMeshRetCode.EVENTMESH_GROUP_PRODUCER_STOPED_ERR.getRetCode());
             responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_GROUP_PRODUCER_STOPED_ERR.getErrMsg());
             responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -253,7 +252,7 @@ public class SendAsyncRemoteEventProcessor implements EventProcessor {
             responseBodyMap.put("retCode", EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode());
             responseBodyMap.put("retMsg", "Event size exceeds the limit: " + eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshEventSize);
             responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -273,7 +272,7 @@ public class SendAsyncRemoteEventProcessor implements EventProcessor {
             responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_PACKAGE_MSG_ERR.getErrMsg() + EventMeshUtil.stackTrace(e, 2));
             responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
 
-            asyncContext.onComplete(responseWrapper);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
             return;
         }
 
@@ -340,8 +339,8 @@ public class SendAsyncRemoteEventProcessor implements EventProcessor {
         } catch (Exception ex) {
             responseBodyMap.put("retCode", EventMeshRetCode.EVENTMESH_SEND_ASYNC_MSG_ERR.getRetCode());
             responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_SEND_ASYNC_MSG_ERR.getErrMsg() + EventMeshUtil.stackTrace(ex, 2));
-            HttpEventWrapper err = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
-            asyncContext.onComplete(err);
+            responseWrapper = asyncContext.getRequest().createHttpResponse(responseHeaderMap, responseBodyMap);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseWrapper, eventMeshHTTPServer);
 
             eventMeshHTTPServer.getHttpRetryer().pushRetry(sendMessageContext.delay(10000));
             long endTime = System.currentTimeMillis();

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendSyncMessageProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendSyncMessageProcessor.java
@@ -104,7 +104,7 @@ public class SendSyncMessageProcessor implements HttpRequestProcessor {
                     SendMessageResponseBody
                             .buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getRetCode(),
                                     EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -125,7 +125,7 @@ public class SendSyncMessageProcessor implements HttpRequestProcessor {
                     SendMessageResponseBody
                             .buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getRetCode(),
                                     EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -152,7 +152,7 @@ public class SendSyncMessageProcessor implements HttpRequestProcessor {
                     SendMessageResponseBody
                             .buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode(),
                                     EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -172,7 +172,7 @@ public class SendSyncMessageProcessor implements HttpRequestProcessor {
                         SendMessageResponseBody
                                 .buildBody(EventMeshRetCode.EVENTMESH_ACL_ERR.getRetCode(),
                                         e.getMessage()));
-                asyncContext.onComplete(responseEventMeshCommand);
+                EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
                 aclLogger.warn("CLIENT HAS NO PERMISSION,SendSyncMessageProcessor send failed", e);
                 return;
             }
@@ -188,7 +188,7 @@ public class SendSyncMessageProcessor implements HttpRequestProcessor {
                     .buildBody(EventMeshRetCode.EVENTMESH_HTTP_MES_SEND_OVER_LIMIT_ERR.getRetCode(),
                         EventMeshRetCode.EVENTMESH_HTTP_MES_SEND_OVER_LIMIT_ERR.getErrMsg()));
             eventMeshHTTPServer.metrics.getSummaryMetrics().recordHTTPDiscard();
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -201,7 +201,7 @@ public class SendSyncMessageProcessor implements HttpRequestProcessor {
                 sendMessageResponseHeader,
                 SendMessageResponseBody.buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode(),
                     "Event size exceeds the limit: " + eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshEventSize));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -214,7 +214,7 @@ public class SendSyncMessageProcessor implements HttpRequestProcessor {
                     SendMessageResponseBody
                             .buildBody(EventMeshRetCode.EVENTMESH_GROUP_PRODUCER_STOPED_ERR.getRetCode(),
                                     EventMeshRetCode.EVENTMESH_GROUP_PRODUCER_STOPED_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -237,7 +237,7 @@ public class SendSyncMessageProcessor implements HttpRequestProcessor {
                             .buildBody(EventMeshRetCode.EVENTMESH_PACKAGE_MSG_ERR.getRetCode(),
                                     EventMeshRetCode.EVENTMESH_PACKAGE_MSG_ERR.getErrMsg()
                                             + EventMeshUtil.stackTrace(e, 2)));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -322,13 +322,13 @@ public class SendSyncMessageProcessor implements HttpRequestProcessor {
                 }
             }, Integer.parseInt(ttl));
         } catch (Exception ex) {
-            HttpCommand err = asyncContext.getRequest().createHttpCommandResponse(
+            responseEventMeshCommand = asyncContext.getRequest().createHttpCommandResponse(
                 sendMessageResponseHeader,
                 SendMessageResponseBody
                     .buildBody(EventMeshRetCode.EVENTMESH_SEND_SYNC_MSG_ERR.getRetCode(),
                         EventMeshRetCode.EVENTMESH_SEND_SYNC_MSG_ERR.getErrMsg()
                             + EventMeshUtil.stackTrace(ex, 2)));
-            asyncContext.onComplete(err);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
 
             eventMeshHTTPServer.getHttpRetryer().pushRetry(sendMessageContext.delay(10000));
             long endTime = System.currentTimeMillis();

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SubscribeProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SubscribeProcessor.java
@@ -102,7 +102,7 @@ public class SubscribeProcessor implements HttpRequestProcessor {
                     SubscribeResponseBody
                             .buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getRetCode(),
                                     EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -116,7 +116,7 @@ public class SubscribeProcessor implements HttpRequestProcessor {
                     SubscribeResponseBody
                             .buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode(),
                                     EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
         List<SubscriptionItem> subTopicList = subscribeRequestBody.getTopics();
@@ -138,7 +138,7 @@ public class SubscribeProcessor implements HttpRequestProcessor {
                             SendMessageResponseBody
                                     .buildBody(EventMeshRetCode.EVENTMESH_ACL_ERR.getRetCode(),
                                             e.getMessage()));
-                    asyncContext.onComplete(responseEventMeshCommand);
+                    EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
                     aclLogger
                             .warn("CLIENT HAS NO PERMISSION,SubscribeProcessor subscribe failed", e);
                     return;
@@ -159,7 +159,7 @@ public class SubscribeProcessor implements HttpRequestProcessor {
                     SubscribeResponseBody
                         .buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode(),
                             EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getErrMsg() + " invalid URL: " + url));
-                asyncContext.onComplete(responseEventMeshCommand);
+                EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
                 return;
             }
         } catch (Exception e) {
@@ -169,7 +169,7 @@ public class SubscribeProcessor implements HttpRequestProcessor {
                 SubscribeResponseBody
                     .buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode(),
                         EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getErrMsg() + " invalid URL: " + url));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -184,7 +184,7 @@ public class SubscribeProcessor implements HttpRequestProcessor {
                 SubscribeResponseBody
                     .buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode(),
                         EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getErrMsg() + " unauthorized webhook URL: " + url));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -284,13 +284,13 @@ public class SubscribeProcessor implements HttpRequestProcessor {
                 responseEventMeshCommand = request.createHttpCommandResponse(EventMeshRetCode.SUCCESS);
                 asyncContext.onComplete(responseEventMeshCommand, handler);
             } catch (Exception e) {
-                HttpCommand err = asyncContext.getRequest().createHttpCommandResponse(
+                responseEventMeshCommand = asyncContext.getRequest().createHttpCommandResponse(
                     subscribeResponseHeader,
                     SubscribeResponseBody
                         .buildBody(EventMeshRetCode.EVENTMESH_SUBSCRIBE_ERR.getRetCode(),
                             EventMeshRetCode.EVENTMESH_SUBSCRIBE_ERR.getErrMsg()
                                 + EventMeshUtil.stackTrace(e, 2)));
-                asyncContext.onComplete(err);
+                EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
                 long endTime = System.currentTimeMillis();
                 httpLogger.error(
                     "message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}"

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/UnSubscribeProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/UnSubscribeProcessor.java
@@ -95,7 +95,7 @@ public class UnSubscribeProcessor implements HttpRequestProcessor {
                     UnSubscribeResponseBody
                             .buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getRetCode(),
                                     EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
 
@@ -109,7 +109,7 @@ public class UnSubscribeProcessor implements HttpRequestProcessor {
                     UnSubscribeResponseBody
                             .buildBody(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode(),
                                     EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getErrMsg()));
-            asyncContext.onComplete(responseEventMeshCommand);
+            EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
             return;
         }
         String env = unSubscribeRequestHeader.getEnv();
@@ -213,13 +213,13 @@ public class UnSubscribeProcessor implements HttpRequestProcessor {
                     asyncContext.onComplete(responseEventMeshCommand, handler);
 
                 } catch (Exception e) {
-                    HttpCommand err = asyncContext.getRequest().createHttpCommandResponse(
+                    responseEventMeshCommand = asyncContext.getRequest().createHttpCommandResponse(
                             unSubscribeResponseHeader,
                             UnSubscribeResponseBody
                                     .buildBody(EventMeshRetCode.EVENTMESH_UNSUBSCRIBE_ERR.getRetCode(),
                                             EventMeshRetCode.EVENTMESH_UNSUBSCRIBE_ERR.getErrMsg()
                                                     + EventMeshUtil.stackTrace(e, 2)));
-                    asyncContext.onComplete(err);
+                    EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
                     long endTime = System.currentTimeMillis();
                     httpLogger.error(
                             "message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms"
@@ -245,13 +245,13 @@ public class UnSubscribeProcessor implements HttpRequestProcessor {
                     eventMeshHTTPServer.localConsumerGroupMapping.keySet()
                             .removeIf(s -> StringUtils.equals(consumerGroup, s));
                 } catch (Exception e) {
-                    HttpCommand err = asyncContext.getRequest().createHttpCommandResponse(
+                    responseEventMeshCommand = asyncContext.getRequest().createHttpCommandResponse(
                             unSubscribeResponseHeader,
                             UnSubscribeResponseBody
                                     .buildBody(EventMeshRetCode.EVENTMESH_UNSUBSCRIBE_ERR.getRetCode(),
                                             EventMeshRetCode.EVENTMESH_UNSUBSCRIBE_ERR.getErrMsg()
                                                     + EventMeshUtil.stackTrace(e, 2)));
-                    asyncContext.onComplete(err);
+                    EventMeshUtil.sendResponseToClient(ctx, asyncContext, responseEventMeshCommand, eventMeshHTTPServer);
                     long endTime = System.currentTimeMillis();
                     httpLogger.error(
                             "message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms"


### PR DESCRIPTION

Fixes ISSUE #1047 

### Motivation

Fix send response twice problem in http server.


### Modifications

- Remove the send response operation in `AbstractHttpServer.java`;
- All the response operation and logic moved into processors.




