### PR TITLE
[ISSUE #1064]Fix NullPointException Of ClientManageControllerTest

### DIFF
--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/admin/controller/ClientManageControllerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/admin/controller/ClientManageControllerTest.java
@@ -28,6 +28,8 @@ import static org.mockito.Mockito.when;
 import org.apache.eventmesh.admin.rocketmq.controller.AdminController;
 import org.apache.eventmesh.runtime.boot.EventMeshTCPServer;
 import org.apache.eventmesh.runtime.configuration.EventMeshTCPConfiguration;
+import org.apache.eventmesh.webhook.admin.AdminWebHookConfigOperationManage;
+import org.apache.eventmesh.webhook.api.WebHookConfigOperation;
 
 import java.io.IOException;
 
@@ -47,6 +49,12 @@ public class ClientManageControllerTest {
         doNothing().when(tcpConfiguration).init();
         when(eventMeshTCPServer.getEventMeshTCPConfiguration()).thenReturn(tcpConfiguration);
         ClientManageController controller = new ClientManageController(eventMeshTCPServer);
+
+        AdminWebHookConfigOperationManage adminWebHookConfigOperationManage = mock(AdminWebHookConfigOperationManage.class);
+        WebHookConfigOperation webHookConfigOperation = mock(WebHookConfigOperation.class);
+        when(adminWebHookConfigOperationManage.getWebHookConfigOperation()).thenReturn(webHookConfigOperation);
+        controller.setAdminWebHookConfigOperationManage(adminWebHookConfigOperationManage);
+
         try (MockedStatic<HttpServer> dummyStatic = Mockito.mockStatic(HttpServer.class)) {
             HttpServer server = mock(HttpServer.class);
             dummyStatic.when(() -> HttpServer.create(any(), anyInt())).thenReturn(server);

--- a/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperation.java
+++ b/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperation.java
@@ -112,7 +112,7 @@ public class FileWebHookConfigOperation implements WebHookConfigOperation {
 
     @Override
     public List<WebHookConfig> queryWebHookConfigByManufacturer(WebHookConfig webHookConfig, Integer pageNum,
-                                                                Integer pageSize) {
+        Integer pageSize) {
         String manuDirPath = getWebhookConfigManuDir(webHookConfig);
         File manuDir = new File(manuDirPath);
         if (!manuDir.exists()) {
@@ -120,12 +120,12 @@ public class FileWebHookConfigOperation implements WebHookConfigOperation {
             return new ArrayList<>();
         }
         List<WebHookConfig> webHookConfigs = new ArrayList<>();
-        
+
         File[] webhookFiles = manuDir.listFiles();
-        if(webhookFiles == null || webhookFiles.length == 0) {
-        	return webHookConfigs;
+        if (webhookFiles == null || webhookFiles.length == 0) {
+            return webHookConfigs;
         }
-        
+
         int startIndex = (pageNum - 1) * pageSize;
         int endIndex = pageNum * pageSize - 1;
         if (webhookFiles.length > startIndex) {
@@ -180,8 +180,8 @@ public class FileWebHookConfigOperation implements WebHookConfigOperation {
         try {
             // use URLEncoder.encode before, because the path may contain some speacial char like '/', which is illegal as a file name.
             webhookConfigFilePath = this.getWebhookConfigManuDir(webHookConfig)
-                    + WebHookOperationConstant.FILE_SEPARATOR + URLEncoder.encode(webHookConfig.getCallbackPath(), "UTF-8")
-                    + WebHookOperationConstant.FILE_EXTENSION;
+                + WebHookOperationConstant.FILE_SEPARATOR + URLEncoder.encode(webHookConfig.getCallbackPath(), "UTF-8")
+                + WebHookOperationConstant.FILE_EXTENSION;
         } catch (UnsupportedEncodingException e) {
             logger.error("get webhookConfig file path {} failed", webHookConfig.getCallbackPath(), e);
         }


### PR DESCRIPTION
Fixes ISSUE #1064 .

### Motivation
When running the ClientManageController unit test, NPE will appear. The reason is that due to the new Webhook feature, it is necessary to add related Mock adaptations.

### Modifications
add AdminWebHookConfigOperationManage mock logic in ClientManageController unit test file.

### Documentation
modify unit test,no need to add new documents
