### PR TITLE
[ISSUE #1243] Upgrade pravega connector 

### DIFF
--- a/eventmesh-connector-plugin/eventmesh-connector-pravega/src/main/java/org/apache/eventmesh/connector/pravega/PravegaConsumerImpl.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-pravega/src/main/java/org/apache/eventmesh/connector/pravega/PravegaConsumerImpl.java
@@ -35,13 +35,15 @@ import lombok.extern.slf4j.Slf4j;
 public class PravegaConsumerImpl implements Consumer {
     private static final AtomicBoolean started = new AtomicBoolean(false);
 
+    private String instanceName;
     private String consumerGroup;
     private PravegaClient client;
     private EventListener eventListener;
 
     @Override
     public void init(Properties keyValue) throws Exception {
-        consumerGroup = keyValue.getProperty("consumerGroup");
+        instanceName = keyValue.getProperty("instanceName", "");
+        consumerGroup = keyValue.getProperty("consumerGroup", "");
         client = PravegaClient.getInstance();
     }
 
@@ -72,7 +74,7 @@ public class PravegaConsumerImpl implements Consumer {
 
     @Override
     public void subscribe(String topic) throws Exception {
-        if (!client.subscribe(topic, consumerGroup, eventListener)) {
+        if (!client.subscribe(topic, consumerGroup, instanceName, eventListener)) {
             throw new PravegaConnectorException(String.format("subscribe topic[%s] fail.", topic));
         }
     }

--- a/eventmesh-connector-plugin/eventmesh-connector-pravega/src/main/java/org/apache/eventmesh/connector/pravega/PravegaConsumerImpl.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-pravega/src/main/java/org/apache/eventmesh/connector/pravega/PravegaConsumerImpl.java
@@ -35,6 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 public class PravegaConsumerImpl implements Consumer {
     private static final AtomicBoolean started = new AtomicBoolean(false);
 
+    private boolean isBroadcast;
     private String instanceName;
     private String consumerGroup;
     private PravegaClient client;
@@ -42,6 +43,7 @@ public class PravegaConsumerImpl implements Consumer {
 
     @Override
     public void init(Properties keyValue) throws Exception {
+        isBroadcast = Boolean.parseBoolean(keyValue.getProperty("isBroadcast", "false"));
         instanceName = keyValue.getProperty("instanceName", "");
         consumerGroup = keyValue.getProperty("consumerGroup", "");
         client = PravegaClient.getInstance();
@@ -74,14 +76,14 @@ public class PravegaConsumerImpl implements Consumer {
 
     @Override
     public void subscribe(String topic) throws Exception {
-        if (!client.subscribe(topic, consumerGroup, instanceName, eventListener)) {
+        if (!client.subscribe(topic, isBroadcast, consumerGroup, instanceName, eventListener)) {
             throw new PravegaConnectorException(String.format("subscribe topic[%s] fail.", topic));
         }
     }
 
     @Override
     public void unsubscribe(String topic) {
-        if (!client.unsubscribe(topic, consumerGroup)) {
+        if (!client.unsubscribe(topic, isBroadcast, consumerGroup)) {
             throw new PravegaConnectorException(String.format("unsubscribe topic[%s] fail.", topic));
         }
     }

--- a/eventmesh-connector-plugin/eventmesh-connector-pravega/src/main/java/org/apache/eventmesh/connector/pravega/PravegaProducerImpl.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-pravega/src/main/java/org/apache/eventmesh/connector/pravega/PravegaProducerImpl.java
@@ -81,7 +81,7 @@ public class PravegaProducerImpl implements Producer {
 
     @Override
     public void sendOneway(CloudEvent cloudEvent) {
-        throw new UnsupportedOperationException();
+        client.publish(cloudEvent.getSubject(), cloudEvent);
     }
 
     @Override

--- a/eventmesh-connector-plugin/eventmesh-connector-pravega/src/test/java/org/apache/eventmesh/connector/pravega/client/PravegaClientTest.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-pravega/src/test/java/org/apache/eventmesh/connector/pravega/client/PravegaClientTest.java
@@ -100,7 +100,7 @@ public class PravegaClientTest {
     public void subscribeTest() {
         PravegaClient pravegaClient = getNewPravegaClient();
         pravegaClient.start();
-        pravegaClient.subscribe("test1", "consumerGroup", new EventListener() {
+        pravegaClient.subscribe("test1", "consumerGroup", "instanceName", new EventListener() {
             @Override
             public void consume(CloudEvent cloudEvent, AsyncConsumeContext context) {
                 // do nothing
@@ -116,7 +116,7 @@ public class PravegaClientTest {
         pravegaClient.unsubscribe("test1", "consumerGroup");
 
         pravegaClient.start();
-        pravegaClient.subscribe("test1", "consumerGroup", new EventListener() {
+        pravegaClient.subscribe("test1", "consumerGroup", "instanceName", new EventListener() {
             @Override
             public void consume(CloudEvent cloudEvent, AsyncConsumeContext context) {
                 // do nothing

--- a/eventmesh-connector-plugin/eventmesh-connector-pravega/src/test/java/org/apache/eventmesh/connector/pravega/client/PravegaClientTest.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-pravega/src/test/java/org/apache/eventmesh/connector/pravega/client/PravegaClientTest.java
@@ -100,7 +100,7 @@ public class PravegaClientTest {
     public void subscribeTest() {
         PravegaClient pravegaClient = getNewPravegaClient();
         pravegaClient.start();
-        pravegaClient.subscribe("test1", "consumerGroup", "instanceName", new EventListener() {
+        pravegaClient.subscribe("test1", false, "consumerGroup", "instanceName", new EventListener() {
             @Override
             public void consume(CloudEvent cloudEvent, AsyncConsumeContext context) {
                 // do nothing
@@ -113,16 +113,16 @@ public class PravegaClientTest {
     @Test
     public void unsubscribeTest() {
         PravegaClient pravegaClient = getNewPravegaClient();
-        pravegaClient.unsubscribe("test1", "consumerGroup");
+        pravegaClient.unsubscribe("test1", false, "consumerGroup");
 
         pravegaClient.start();
-        pravegaClient.subscribe("test1", "consumerGroup", "instanceName", new EventListener() {
+        pravegaClient.subscribe("test1", false, "consumerGroup", "instanceName", new EventListener() {
             @Override
             public void consume(CloudEvent cloudEvent, AsyncConsumeContext context) {
                 // do nothing
             }
         });
-        pravegaClient.unsubscribe("test1", "consumerGroup");
+        pravegaClient.unsubscribe("test1", false, "consumerGroup");
 
         assertFalse(pravegaClient.getSubscribeTaskMap().containsKey("test1"));
         try {


### PR DESCRIPTION
Fixes issue #1243. Related PR #1203.

### Motivation

Upgrade pravega connector

### Modifications

- SubscribeTask supports EventMeshAsyncConsumeContext.commit
- Consumer support broadcast and clustering message model
- Upgrade the creation of ReaderGroup and Reader. 
  - Use `{consumerGroup}-{topic}` for clustering model or UUID for broadcast model as ReaderGroup name
  - Set `AUTOMATIC_RELEASE_AT_LAST_CHECKPOINT` as the retention strategy of all ReaderGroup
