### PR TITLE
[#1091]java sdk add nacos selector

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/Constants.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/Constants.java
@@ -164,4 +164,14 @@ public class Constants {
      * application/cloudevents+json Content-type
      */
     public static final String CONTENT_TYPE_CLOUDEVENTS_JSON = "application/cloudevents+json";
+
+    public static final String CONFIG_FILE_NAME = "application.properties";
+
+    public static final String EVENTMESH_SELECTOR_TYPE = "eventmesh.selector.type";
+
+    public static final String EVENTMESH_SELECTOR_NACOS_ADDRESS = "eventmesh.selector.nacos.address_list";
+
+    public static final String EVENTMESH_WORKFLOW_SERVER_NAME = "eventmesh.workflow.server.name";
+
+    public static final String EVENTMESH_CATALOG_SERVER_NAME = "eventmesh.catalog.server.name";
 }

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/PropertiesUtils.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/PropertiesUtils.java
@@ -21,6 +21,7 @@ import org.apache.eventmesh.common.Constants;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.InputStream;
 import java.util.Properties;
 
 public class PropertiesUtils {
@@ -60,5 +61,15 @@ public class PropertiesUtils {
             }
         );
         return to;
+    }
+
+    public static Properties readPropertiesFile(String fileName) {
+        try (final InputStream inputStream = PropertiesUtils.class.getClassLoader().getResourceAsStream(fileName)) {
+            Properties properties = new Properties();
+            properties.load(inputStream);
+            return properties;
+        } catch (Exception e) {
+            throw new IllegalArgumentException(String.format("File: %s is not exist", fileName));
+        }
     }
 }

--- a/eventmesh-sdk-java/build.gradle
+++ b/eventmesh-sdk-java/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     implementation "io.grpc:grpc-netty:${grpcVersion}"
     implementation "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
+    implementation "com.alibaba.nacos:nacos-client:2.0.4"
+
     // protocol
     api "io.cloudevents:cloudevents-core"
     api "io.cloudevents:cloudevents-json-jackson"

--- a/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/selector/NacosSelector.java
+++ b/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/selector/NacosSelector.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.client.selector;
+
+import org.apache.eventmesh.common.Constants;
+import org.apache.eventmesh.common.utils.PropertiesUtils;
+
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.NamingFactory;
+import com.alibaba.nacos.api.naming.NamingService;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+
+public class NacosSelector implements Selector {
+    private static final Logger logger = LoggerFactory.getLogger(NacosSelector.class);
+    private NamingService namingService;
+
+    public void init() throws Exception {
+        try {
+            Properties properties = PropertiesUtils.readPropertiesFile(Constants.CONFIG_FILE_NAME);
+            namingService = NamingFactory.createNamingService(properties.getProperty(Constants.EVENTMESH_SELECTOR_NACOS_ADDRESS));
+        } catch (NacosException e) {
+            logger.error("[NacosSelector][init] error", e);
+            throw new Exception(e.getMessage());
+        }
+    }
+
+    @Override
+    public ServiceInstance selectOne(String serviceName) throws Exception {
+        try {
+            Instance instance = namingService.selectOneHealthyInstance(serviceName);
+            if (instance == null) {
+                return null;
+            }
+            ServiceInstance serviceInstance = new ServiceInstance();
+            serviceInstance.setHost(instance.getIp());
+            serviceInstance.setPort(instance.getPort());
+            serviceInstance.setHealthy(instance.isHealthy());
+            serviceInstance.setMetadata(instance.getMetadata());
+            return serviceInstance;
+        } catch (NacosException e) {
+            logger.error("[NacosSelector][selectOne] error", e);
+            throw new Exception(e.getMessage());
+        }
+    }
+}

--- a/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/selector/Selector.java
+++ b/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/selector/Selector.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.client.selector;
+
+/**
+ * Selector is the abstract of selecting registry service instances
+ */
+public interface Selector {
+
+    ServiceInstance selectOne(String serverName) throws Exception;
+}

--- a/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/selector/SelectorFactory.java
+++ b/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/selector/SelectorFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.client.selector;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SelectorFactory {
+    private static final Map<String, Selector> selectorMap = new HashMap<>();
+
+    static {
+        selectorMap.put("nacos", new NacosSelector());
+    }
+
+    public static Selector get(String type) {
+        return selectorMap.getOrDefault(type, new NacosSelector());
+    }
+}

--- a/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/selector/ServiceInstance.java
+++ b/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/selector/ServiceInstance.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.client.selector;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.Data;
+
+@Data
+public class ServiceInstance implements Serializable {
+
+    private static final long serialVersionUID = -5770826614635186498L;
+
+    private String host;
+    private int port;
+    private boolean isHealthy;
+    private Map<String, String> metadata;
+
+    public ServiceInstance() {
+        this.host = null;
+        this.port = 0;
+        this.isHealthy = true;
+        this.metadata = new HashMap<>();
+    }
+
+    public String getParameter(String key) {
+        if (metadata.get(key) != null) {
+            return String.valueOf(metadata.get(key));
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Fixes #1091 

### Motivation
Applications can access the EventMesh Workflow/AysncAPI capabilities through the EventMesh SDK to fill the event governance capabilities

### Modifications
1. add nacos naming selector

### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
