### PR TITLE
[ISSUE#1244]java sdk add selector interface

### DIFF
--- a/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/selector/Selector.java
+++ b/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/selector/Selector.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.client.selector;
+
+/**
+ * Selector is the abstract of selecting registry service instances
+ */
+public interface Selector {
+    ServiceInstance selectOne(String serverName) throws SelectorException;
+}

--- a/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/selector/SelectorException.java
+++ b/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/selector/SelectorException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.client.selector;
+
+public class SelectorException extends RuntimeException {
+    private static final long serialVersionUID = 7126682512429265292L;
+
+    public SelectorException(String message) {
+        super(message);
+    }
+
+    public SelectorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/selector/SelectorFactory.java
+++ b/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/selector/SelectorFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.client.selector;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SelectorFactory {
+    private static final Map<String, Selector> selectorMap = new HashMap<>();
+
+    public static Selector get(String type) {
+        return selectorMap.get(type);
+    }
+
+    public static void register(String type, Selector selector) {
+        if (selector == null) {
+            return;
+        }
+        selectorMap.put(type, selector);
+    }
+}

--- a/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/selector/ServiceInstance.java
+++ b/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/selector/ServiceInstance.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.client.selector;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.Data;
+
+@Data
+public class ServiceInstance implements Serializable {
+
+    private static final long serialVersionUID = -5770826614635186498L;
+
+    private String host;
+    private int port;
+    private boolean isHealthy;
+    private Map<String, String> metadata;
+
+    public ServiceInstance() {
+        this.host = null;
+        this.port = 0;
+        this.isHealthy = true;
+        this.metadata = new HashMap<>();
+    }
+}


### PR DESCRIPTION
Fixes #1244  

### Motivation
the sdk currently lacks name service addressing capabilities, so a selector module is added to support name service addressing. the sdk is responsible for defining the interface, and users need to implement the naming selector by themselves.

### Modifications
1. add selector interface

### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
