### PR TITLE
[ISSUE #1307] Knative Connector: Support Cluster-Mode and Broadcast-Mode Listener.

### DIFF
--- a/eventmesh-connector-plugin/eventmesh-connector-knative/src/main/java/org/apache/eventmesh/connector/knative/consumer/PullConsumerImpl.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-knative/src/main/java/org/apache/eventmesh/connector/knative/consumer/PullConsumerImpl.java
@@ -21,6 +21,7 @@ import org.apache.eventmesh.api.AbstractContext;
 import org.apache.eventmesh.api.EventListener;
 import org.apache.eventmesh.api.EventMeshAction;
 import org.apache.eventmesh.api.EventMeshAsyncConsumeContext;
+import org.apache.eventmesh.common.ThreadPoolFactory;
 import org.apache.eventmesh.common.protocol.SubscriptionItem;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.SubscriptionType;
@@ -33,14 +34,20 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.cloudevents.CloudEvent;
 
 import com.google.common.collect.Lists;
 
 public class PullConsumerImpl {
+
+    private final Logger logger = LoggerFactory.getLogger(PullConsumerImpl.class);
 
     private final DefaultConsumer defaultConsumer;
 
@@ -51,35 +58,59 @@ public class PullConsumerImpl {
     private final Properties properties;
 
     // Store received message:
-    public ConcurrentMap<String /* topic */, String /* responseBody */> subscriptionInner;
+    public ConcurrentMap<String /* topic */, CloudEvent /* CloudEvent message */> subscriptionInner;
     public EventListener eventListener;
+
+    private final ExecutorService consumeExecutorService;
 
     public PullConsumerImpl(final Properties properties) throws Exception {
         this.properties = properties;
         this.topicList = Lists.newArrayList();
-        this.subscriptionInner = new ConcurrentHashMap<String, String>();
+        this.subscriptionInner = new ConcurrentHashMap<String, CloudEvent>();
         this.offsetMap = new ConcurrentHashMap<>();
         defaultConsumer = new DefaultConsumer();
 
         // Register listener:
-        defaultConsumer.registerMessageListener(new ClusteringMessageListener());
+        if (properties.getProperty("isBroadcast").equals("true")) {
+            defaultConsumer.registerMessageListener(new BroadCastingMessageListener());
+        } else {
+            defaultConsumer.registerMessageListener(new ClusteringMessageListener());
+        }
+
+        // Init KnativeConsumer thread:
+        this.consumeExecutorService = ThreadPoolFactory.createThreadPoolExecutor(
+            Runtime.getRuntime().availableProcessors() * 2,
+            Runtime.getRuntime().availableProcessors() * 2,
+            "KnativeConsumerThread"
+        );
     }
 
     public void subscribe(String topic) {
-        // Subscribe topics:
+        // Add topic to topicList:
+        topicList.add(new SubscriptionItem(topic, SubscriptionMode.CLUSTERING, SubscriptionType.ASYNC));
+        // Pull event messages according to topic:
         try {
-            // Add topic to topicList:
-            topicList.add(new SubscriptionItem(topic, SubscriptionMode.CLUSTERING, SubscriptionType.ASYNC));
-            // Pull event messages iteratively:
-            topicList.forEach(
-                item -> {
-                    try {
-                        subscriptionInner.put(item.getTopic(), defaultConsumer.pullMessage(item.getTopic(), properties.getProperty("serviceAddr")));
-                    } catch (Exception e) {
-                        e.printStackTrace();
+            subscriptionInner.put(topic, defaultConsumer.pullMessage(topic, properties.getProperty("serviceAddr")));
+            // Directly consume message by listener (EventMesh server):
+            EventMeshAsyncConsumeContext consumeContext = new EventMeshAsyncConsumeContext() {
+                @Override
+                public void commit(EventMeshAction action) {
+                    switch (action) {
+                        case CommitMessage:
+                            // update offset
+                            logger.info("message commit, topic: {}", topic);
+                            break;
+                        case ReconsumeLater:
+                            // don't update offset
+                            break;
+                        case ManualAck:
+                            logger.info("message ack, topic: {}", topic);
+                            break;
+                        default:
                     }
                 }
-            );
+            };
+            eventListener.consume(subscriptionInner.get(topic), consumeContext);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -94,7 +125,6 @@ public class PullConsumerImpl {
         }
     }
 
-    // todo: offset
     public void updateOffset(List<CloudEvent> cloudEvents, AbstractContext context) {
         cloudEvents.forEach(cloudEvent -> this.updateOffset(
             cloudEvent.getSubject(), (Long) cloudEvent.getExtension("offset"))
@@ -128,9 +158,50 @@ public class PullConsumerImpl {
         this.eventListener = listener;
     }
 
-    // todo: load balancer cluser and broadcast
+    private class BroadCastingMessageListener extends EventMeshMessageListenerConcurrently {
+        @Override
+        public EventMeshConsumeConcurrentlyStatus handleMessage(CloudEvent cloudEvent, EventMeshConsumeConcurrentlyContext context) {
+            final Properties contextProperties = new Properties();
+            contextProperties.put(NonStandardKeys.MESSAGE_CONSUME_STATUS,
+                EventMeshConsumeConcurrentlyStatus.RECONSUME_LATER.name());
+            EventMeshAsyncConsumeContext eventMeshAsyncConsumeContext = new EventMeshAsyncConsumeContext() {
+                @Override
+                public void commit(EventMeshAction action) {
+                    switch (action) {
+                        case CommitMessage:
+                            contextProperties.put(NonStandardKeys.MESSAGE_CONSUME_STATUS,
+                                EventMeshConsumeConcurrentlyStatus.CONSUME_SUCCESS.name());
+                            break;
+                        case ReconsumeLater:
+                            contextProperties.put(NonStandardKeys.MESSAGE_CONSUME_STATUS,
+                                EventMeshConsumeConcurrentlyStatus.RECONSUME_LATER.name());
+                            break;
+                        case ManualAck:
+                            contextProperties.put(NonStandardKeys.MESSAGE_CONSUME_STATUS,
+                                EventMeshConsumeConcurrentlyStatus.CONSUME_FINISH.name());
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            };
+
+            eventMeshAsyncConsumeContext.setAbstractContext((AbstractContext) context);
+
+            // Consume received message:
+            eventListener.consume(cloudEvent, eventMeshAsyncConsumeContext);
+
+            return EventMeshConsumeConcurrentlyStatus.valueOf(
+                contextProperties.getProperty(NonStandardKeys.MESSAGE_CONSUME_STATUS));
+        }
+    }
+
     private class ClusteringMessageListener extends EventMeshMessageListenerConcurrently {
         public EventMeshConsumeConcurrentlyStatus handleMessage(CloudEvent cloudEvent, EventMeshConsumeConcurrentlyContext context) {
+            if (cloudEvent == null) {
+                return EventMeshConsumeConcurrentlyStatus.CONSUME_SUCCESS;
+            }
+
             final Properties contextProperties = new Properties();
             contextProperties.put(NonStandardKeys.MESSAGE_CONSUME_STATUS, EventMeshConsumeConcurrentlyStatus.RECONSUME_LATER.name());
 


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Cloese #<XXX>`.)
-->

Fixed #1307.

### Motivation

*Support cluster-mode and broadcast-mode listener in Knative-Connector.*
*This PR will be merged into knative-connector branch first.*



### Modifications

#### Logic
Listener (cluster or broadcast mode) calls ```consume``` method after ```subscribe``` according to action type (CommitMessage, ReconsumeLater, or ManualACK).

#### Implementation
- Added broadcast-mode message listener
- Added ```consume``` statement calling in ```subscribe``` method

#### How to Test
Same as the integration test steps in demo (see [document](https://github.com/apache/incubator-eventmesh/blob/master/docs/zh/connector-knative/01-eventmesh-connector-knative.md) for details)



### Documentation

- Does this pull request introduce a new feature? Yes.
- If yes, how is the feature documented? Not documented.
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation. The documentation issue will be created along with another PR specifically for documentation.
