### PR TITLE
[ISSUE#1518][Enhancement] Method check a map with containsKey(), before using get() [BatchMessage]

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/grpc/protos/BatchMessage.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/grpc/protos/BatchMessage.java
@@ -578,7 +578,11 @@ private static final long serialVersionUID = 0L;
       if (key == null) { throw new NullPointerException(); }
       java.util.Map<String, String> map =
           internalGetProperties().getMap();
-      return map.containsKey(key) ? map.get(key) : defaultValue;
+      String value = map.get(key);
+      if(value != null)
+        return  map.get(key);
+      else
+        return defaultValue;
     }
     /**
      * <code>map&lt;string, string&gt; properties = 6;</code>
@@ -1403,7 +1407,11 @@ private static final long serialVersionUID = 0L;
         if (key == null) { throw new NullPointerException(); }
         java.util.Map<String, String> map =
             internalGetProperties().getMap();
-        return map.containsKey(key) ? map.get(key) : defaultValue;
+        String value = map.get(key);
+        if(value != null)
+          return  map.get(key);
+        else
+          return defaultValue;
       }
       /**
        * <code>map&lt;string, string&gt; properties = 6;</code>


### PR DESCRIPTION
Fixes #1518 .

Motivation

This method checks for the presence of a key in a map using containsKey(), before attempting to fetch the value of the key using get(). This equates to doing two map lookups in a row.

 Modifications

Instead of using containsKey() method, changed it to storing the value that we got from get() in a variable and check if it is not null.
String value = map.get(key);
      if(value != null)
        return  map.get(key);
      else
        return defaultValue;

Documentation

- Does this pull request introduce a new feature?  no
