### PR TITLE
[ISSUE #1535] Method uses integer based for loops to iterate over a List [QueryOperationsResponse]

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/catalog/protos/QueryOperationsResponse.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/catalog/protos/QueryOperationsResponse.java
@@ -180,8 +180,8 @@ public final class QueryOperationsResponse extends
     @Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
         throws java.io.IOException {
-        for (int i = 0; i < operations_.size(); i++) {
-            output.writeMessage(1, operations_.get(i));
+        for (Operation operation : operations_) {
+            output.writeMessage(1, operation);
         }
         unknownFields.writeTo(output);
     }
@@ -194,9 +194,9 @@ public final class QueryOperationsResponse extends
         }
 
         size = 0;
-        for (int i = 0; i < operations_.size(); i++) {
+        for (Operation operation : operations_) {
             size += com.google.protobuf.CodedOutputStream
-                .computeMessageSize(1, operations_.get(i));
+                .computeMessageSize(1, operation);
         }
         size += unknownFields.getSerializedSize();
         memoizedSize = size;

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/grpc/protos/BatchMessage.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/grpc/protos/BatchMessage.java
@@ -578,7 +578,11 @@ private static final long serialVersionUID = 0L;
       if (key == null) { throw new NullPointerException(); }
       java.util.Map<String, String> map =
           internalGetProperties().getMap();
-      return map.containsKey(key) ? map.get(key) : defaultValue;
+      String value = map.get(key);
+      if(value != null)
+        return  map.get(key);
+      else
+        return defaultValue;
     }
     /**
      * <code>map&lt;string, string&gt; properties = 6;</code>
@@ -1403,7 +1407,11 @@ private static final long serialVersionUID = 0L;
         if (key == null) { throw new NullPointerException(); }
         java.util.Map<String, String> map =
             internalGetProperties().getMap();
-        return map.containsKey(key) ? map.get(key) : defaultValue;
+        String value = map.get(key);
+        if(value != null)
+          return  map.get(key);
+        else
+          return defaultValue;
       }
       /**
        * <code>map&lt;string, string&gt; properties = 6;</code>

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/grpc/protos/BatchMessage.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/grpc/protos/BatchMessage.java
@@ -578,11 +578,7 @@ private static final long serialVersionUID = 0L;
       if (key == null) { throw new NullPointerException(); }
       java.util.Map<String, String> map =
           internalGetProperties().getMap();
-      String value = map.get(key);
-      if(value != null)
-        return  map.get(key);
-      else
-        return defaultValue;
+      return map.containsKey(key) ? map.get(key) : defaultValue;
     }
     /**
      * <code>map&lt;string, string&gt; properties = 6;</code>
@@ -1407,11 +1403,7 @@ private static final long serialVersionUID = 0L;
         if (key == null) { throw new NullPointerException(); }
         java.util.Map<String, String> map =
             internalGetProperties().getMap();
-        String value = map.get(key);
-        if(value != null)
-          return  map.get(key);
-        else
-          return defaultValue;
+        return map.containsKey(key) ? map.get(key) : defaultValue;
       }
       /**
        * <code>map&lt;string, string&gt; properties = 6;</code>


### PR DESCRIPTION
Fixes #1535 

Motivation
This method uses an integer-based for loop to iterate over a java.util.List, by calling List.get(i) each time through the loop. The integer is not used for other reasons.

 Modifications

Instead for loop, replaced it with foreach loop

Documentation

- Does this pull request introduce a new feature?   no
