### PR TITLE
[ISSUE #1537] Replace integer based for loop with foreach loop

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/grpc/protos/Heartbeat.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/grpc/protos/Heartbeat.java
@@ -1063,8 +1063,8 @@ private static final long serialVersionUID = 0L;
     if (!getConsumerGroupBytes().isEmpty()) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 4, consumerGroup_);
     }
-    for (int i = 0; i < heartbeatItems_.size(); i++) {
-      output.writeMessage(5, heartbeatItems_.get(i));
+    for (HeartbeatItem heartbeatItem: heartbeatItems_) {
+      output.writeMessage(5, heartbeatItem);
     }
     unknownFields.writeTo(output);
   }
@@ -1088,9 +1088,9 @@ private static final long serialVersionUID = 0L;
     if (!getConsumerGroupBytes().isEmpty()) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, consumerGroup_);
     }
-    for (int i = 0; i < heartbeatItems_.size(); i++) {
+    for (HeartbeatItem heartbeatItem: heartbeatItems_) {
       size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(5, heartbeatItems_.get(i));
+        .computeMessageSize(5, heartbeatItem);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;


### PR DESCRIPTION
Fixes #1537

### Motivation
Integer-based for loop is used to iterate over a java.util.List, by calling List.get(i) each time through the loop. The integer is not used for other reasons. It is better to use an Iterator instead, as depending on List implementation, iterators can perform better, and they also allow for exchanging of other collection types without issue.

### Modifications
* Update existing integer based for loop with the enhanced for loop.

### Documentation

- Does this pull request introduce a new feature? (yes / no) **No**
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) **NA**
- If a feature is not applicable for documentation, explain why? **NA**
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation **NA**
