### PR TITLE
[ISSUE #1557] Uses Parameterized logging in KafkaConsumerRunner instead of String Concatenation

### DIFF
--- a/eventmesh-connector-plugin/eventmesh-connector-kafka/src/main/java/org/apache/eventmesh/connector/kafka/consumer/KafkaConsumerRunner.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-kafka/src/main/java/org/apache/eventmesh/connector/kafka/consumer/KafkaConsumerRunner.java
@@ -92,7 +92,7 @@ public class KafkaConsumerRunner implements Runnable {
                             listener.consume(cloudEvent, eventMeshAsyncConsumeContext);
                         }
                     } catch (Exception e) {
-                        logger.info("Error parsing cloudevents: " + e.getMessage());
+                        logger.info("Error parsing cloudevents: {}", e.getMessage());
                     }
                 });
             } catch (WakeupException e) {


### PR DESCRIPTION
Fixes #1557

### Modifications

Make use of SLF4J parameterized logging instead of String concatenation

### Documentation

- Does this pull request introduce a new feature? no
