### PR TITLE
[ISSUE #1533] | Method prints the stack trace to the console

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/IPUtils.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/IPUtils.java
@@ -111,9 +111,9 @@ public class IPUtils {
             final InetAddress localHost = InetAddress.getLocalHost();
             return normalizeHostAddress(localHost);
         } catch (SocketException e) {
-            e.printStackTrace();
+            logger.error(e.getMessage());
         } catch (UnknownHostException e) {
-            e.printStackTrace();
+            logger.error(e.getMessage());
         }
 
         return null;


### PR DESCRIPTION

Fixes #1533 

### Motivation

This method prints a stack trace to the console. I have updated them to log it using the appropriate loggers. 






### Documentation

- Does this pull request introduce a new feature? (yes / no) No 
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
