### PR TITLE
[ISSUE #1627] refresh consumerGroupConfig of eventMeshConsumer

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/ConsumerGroupManager.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/ConsumerGroupManager.java
@@ -78,6 +78,7 @@ public class ConsumerGroupManager {
         }
 
         this.consumerGroupConfig = consumerGroupConfig;
+        this.eventMeshConsumer.setConsumerGroupConf(consumerGroupConfig);
         init();
         start();
     }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/EventMeshConsumer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/EventMeshConsumer.java
@@ -298,6 +298,10 @@ public class EventMeshConsumer {
         return consumerGroupConf;
     }
 
+    public void setConsumerGroupConf(ConsumerGroupConf consumerGroupConf) {
+        this.consumerGroupConf = consumerGroupConf;
+    }
+
     public EventMeshHTTPServer getEventMeshHTTPServer() {
         return eventMeshHTTPServer;
     }


### PR DESCRIPTION
Fixes #1627 .

### Motivation

When one consumer group subscribes multiple topics, only the first subscription can invoke the url.



### Modifications

Set the consumerGroupConfig of EventMeshConsumer, when invoke the refresh method of ConsumerGroupManager.


### Documentation

- Does this pull request introduce a new feature? (yes / no)
- no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
