### PR TITLE
[ISSUE #1637] delete double serialization of topic

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalSubscribeEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalSubscribeEventProcessor.java
@@ -129,7 +129,7 @@ public class LocalSubscribeEventProcessor extends AbstractEventProcessor impleme
 
         String url = requestBodyMap.get("url").toString();
         String consumerGroup = requestBodyMap.get("consumerGroup").toString();
-        String topic = JsonUtils.serialize(requestBodyMap.get("topic"));
+        String topic = requestBodyMap.get("topic").toString();
 
         // SubscriptionItem
         List<SubscriptionItem> subscriptionList = JsonUtils.deserialize(topic, new TypeReference<List<SubscriptionItem>>() {


### PR DESCRIPTION
Fixes #1637 .

### Motivation
When I subscribe one event by LocalSubscribeEventProcessor, I found that topic deserialization occurs an error.
Because of the unexpected escape character.


### Modifications

remove double serialization of topic field.



### Documentation

- Does this pull request introduce a new feature? (yes / no)
- no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
