### PR TITLE
[ISSUE #1558] Replacing default encoding with UTF-8 in ConfigurationWrapper

### DIFF
--- a/eventmesh-connector-plugin/eventmesh-connector-kafka/src/main/java/org/apache/eventmesh/connector/kafka/config/ConfigurationWrapper.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-kafka/src/main/java/org/apache/eventmesh/connector/kafka/config/ConfigurationWrapper.java
@@ -24,9 +24,11 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 import lombok.experimental.UtilityClass;
@@ -62,7 +64,9 @@ public class ConfigurationWrapper {
         try {
             String configPath = Constants.EVENTMESH_CONF_HOME + File.separator + EventMeshConstants.EVENTMESH_CONF_FILE;
             if (new File(configPath).exists()) {
-                properties.load(new BufferedReader(new FileReader(configPath)));
+                try(BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(configPath), StandardCharsets.UTF_8))) {
+                    properties.load(reader);
+                }
             }
         } catch (IOException e) {
             throw new IllegalArgumentException(String.format("Cannot load %s file from conf", EventMeshConstants.EVENTMESH_CONF_FILE));

--- a/eventmesh-connector-plugin/eventmesh-connector-kafka/src/main/java/org/apache/eventmesh/connector/kafka/config/ConfigurationWrapper.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-kafka/src/main/java/org/apache/eventmesh/connector/kafka/config/ConfigurationWrapper.java
@@ -64,7 +64,9 @@ public class ConfigurationWrapper {
         try {
             String configPath = Constants.EVENTMESH_CONF_HOME + File.separator + EventMeshConstants.EVENTMESH_CONF_FILE;
             if (new File(configPath).exists()) {
-                try(BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(configPath), StandardCharsets.UTF_8))) {
+                try(FileInputStream fileInputStream = new FileInputStream(configPath);
+                    InputStreamReader inputStreamReader = new InputStreamReader(fileInputStream, StandardCharsets.UTF_8);
+                    BufferedReader reader = new BufferedReader(inputStreamReader)) {
                     properties.load(reader);
                 }
             }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Cloese #<XXX>`.)
-->

Fixes #1558 

### Motivation
ConfigurationWrapper is using the default encoding while reading the data from a file in configPath, and this might cause application behaviour to vary between platforms, as described in https://github.com/apache/incubator-eventmesh/issues/1558
	
	
### Modifications
I have made changes to read the contents of the file in a fixed UTF-8 format, and this is possible by using the InputStreamReader.
	
	
### Documentation
	
- Does this pull request introduce a new feature? No, it's a fix to handle edge cases.

