### PR TITLE
[ISSUE #1674] remove external grpc conn close logic

### DIFF
--- a/eventmesh-sdk-go/grpc/producer.go
+++ b/eventmesh-sdk-go/grpc/producer.go
@@ -48,7 +48,7 @@ func newProducer(grpcConn *grpc.ClientConn) (*eventMeshProducer, error) {
 
 // Close recover all resource hold in the producer
 func (e *eventMeshProducer) Close() error {
-	log.Infof("close eventmesh producer")
+	log.Infof("close eventmesh grpc conn")
 	return nil
 }
 

--- a/eventmesh-sdk-go/grpc/producer.go
+++ b/eventmesh-sdk-go/grpc/producer.go
@@ -48,7 +48,7 @@ func newProducer(grpcConn *grpc.ClientConn) (*eventMeshProducer, error) {
 
 // Close recover all resource hold in the producer
 func (e *eventMeshProducer) Close() error {
-	log.Infof("close eventmesh grpc conn")
+	log.Infof("close eventmesh producer")
 	return nil
 }
 


### PR DESCRIPTION
Fixes #1674.

### Motivation
fix golang-sdk publish error: connection closed before server preface received

### Modifications
remove the external grpc conn close logic.

### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
