### PR TITLE
[ISSUE #1654] fix NullPointerException of broadcastEventListener

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/EventMeshConsumer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/EventMeshConsumer.java
@@ -194,9 +194,8 @@ public class EventMeshConsumer {
                         .build();
 
                     String topic = event.getSubject();
-                    String bizSeqNo =
-                        event.getExtension(Constants.PROPERTY_MESSAGE_SEARCH_KEYS).toString();
-                    String uniqueId = event.getExtension(Constants.RMB_UNIQ_ID).toString();
+                    String bizSeqNo = event.getExtension(ProtocolKey.ClientInstanceKey.BIZSEQNO).toString();
+                    String uniqueId = event.getExtension(ProtocolKey.ClientInstanceKey.UNIQUEID).toString();
 
                     if (messageLogger.isDebugEnabled()) {
                         messageLogger.debug("message|mq2eventMesh|topic={}|msg={}", topic, event);


### PR DESCRIPTION
Fixes #1654 .

### Motivation
It occurs an NullPonterException when broadcastEventListener consumes message.



### Modifications

Change the nonexistent fields to others.


### Documentation

- Does this pull request introduce a new feature? (yes / no)
- no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
