### PR TITLE
[1686] Field isn't final but should be [grpc SendMessageContext]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/producer/SendMessageContext.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/producer/SendMessageContext.java
@@ -33,7 +33,7 @@ import io.cloudevents.CloudEvent;
 
 public class SendMessageContext extends RetryContext {
 
-    public static Logger logger = LoggerFactory.getLogger("retry");
+    public static final Logger logger = LoggerFactory.getLogger("retry");
 
     private CloudEvent event;
 


### PR DESCRIPTION
Fixes [#1686](https://github.com/apache/incubator-eventmesh/issues/1686)

### Motivation
This static field public but not final, and could be changed by malicious code or by accident from another package. The field could be made final to avoid this vulnerability.

### Modifications
Add final keyword to avoid vulnerability

### Documentation

- Does this pull request introduce a new feature? (yes / no) no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation