### PR TITLE
[ISSUE #1688] Field isn't final but should be [HTTPMessageHandler]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/push/HTTPMessageHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/push/HTTPMessageHandler.java
@@ -64,7 +64,7 @@ public class HTTPMessageHandler implements MessageHandler {
         });
     }
 
-    public static Map<String, Set<AbstractHTTPPushRequest>> waitingRequests = Maps.newConcurrentMap();
+    public static final Map<String, Set<AbstractHTTPPushRequest>> waitingRequests = Maps.newConcurrentMap();
 
     public HTTPMessageHandler(EventMeshConsumer eventMeshConsumer) {
         this.eventMeshConsumer = eventMeshConsumer;


### PR DESCRIPTION
Fixes #1688

### Motivation

This static field public but not final, and could be changed by malicious code or by accident from another package. The field could be made final to avoid this vulnerability.


### Modifications

Add final keyword to avoid vulnerability

### Documentation

- Does this pull request introduce a new feature? (yes / no) no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
