### PR TITLE
[ISSUE #1697] Modify Invocation of toString on an array 

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/HelloTask.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/HelloTask.java
@@ -73,7 +73,7 @@ public class HelloTask extends AbstractTask {
             Utils.writeAndFlush(res, startTime, taskExecuteTime, session.getContext(), session);
         } catch (Throwable e) {
             messageLogger.error("HelloTask failed|address={},errMsg={}", ctx.channel().remoteAddress(), e);
-            res.setHeader(new Header(HELLO_RESPONSE, OPStatus.FAIL.getCode(), e.getStackTrace().toString(), pkg
+            res.setHeader(new Header(HELLO_RESPONSE, OPStatus.FAIL.getCode(), Arrays.toString(e.getStackTrace()), pkg
                     .getHeader().getSeq()));
             ctx.writeAndFlush(res).addListener(
                     new ChannelFutureListener() {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/HelloTask.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/HelloTask.java
@@ -34,14 +34,14 @@ import org.apache.eventmesh.runtime.util.Utils;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Arrays;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
-
-import java.util.Arrays;
 
 public class HelloTask extends AbstractTask {
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/HelloTask.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/HelloTask.java
@@ -41,6 +41,8 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 
+import java.util.Arrays;
+
 public class HelloTask extends AbstractTask {
 
     private final Logger messageLogger = LoggerFactory.getLogger("message");


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Cloese #<XXX>`.)
-->

Fixes #1697 

### Motivation

located at:
org/apache/eventmesh/runtime/core/protocol/tcp/client/task/HelloTask.java line 76
The code invokes toString on an array, which will generate a fairly useless result. This needs to be updated to use Arrays.toString() instead

### Modifications

In line 76, modified invocation of toString to an array [Arrays.toString()].

### Documentation

- Does this pull request introduce a new feature?  (no)
- If yes, how is the feature documented? (not applicable)
- If a feature is not applicable for documentation, explain why?(minor enhancement fix)
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation(-)
