### PR TITLE
[ISSUE #1818] Fix IOException in SSLContextFactory

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/SSLContextFactory.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/SSLContextFactory.java
@@ -49,7 +49,7 @@ public class SSLContextFactory {
 
     public static SSLContext getSslContext(EventMeshHTTPConfiguration eventMeshHttpConfiguration) {
         SSLContext sslContext;
-        InputStream inputStream;
+        InputStream inputStream = null;
         try {
             protocol = eventMeshHttpConfiguration.eventMeshServerSSLProtocol;
 
@@ -64,7 +64,7 @@ public class SSLContextFactory {
             KeyStore keyStore = KeyStore.getInstance("JKS");
             inputStream = Files.newInputStream(Paths.get(EventMeshConstants.EVENTMESH_CONF_HOME
                                               + File.separator
-                                              + fileName), StandardOpenOption.READ)
+                                              + fileName), StandardOpenOption.READ);
             keyStore.load(inputStream, filePass);
             KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
             kmf.init(keyStore, filePass);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/SSLContextFactory.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/SSLContextFactory.java
@@ -25,6 +25,7 @@ import org.apache.eventmesh.runtime.constants.EventMeshConstants;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -72,9 +73,14 @@ public class SSLContextFactory {
         } catch (Exception e) {
             httpLogger.warn("sslContext init failed", e);
             sslContext = null;
-        } finally {
+        }
+        finally {
             if (inputStream != null) {
-                inputStream.close();
+                try{
+                    inputStream.close();
+                }catch(IOException e){
+                    httpLogger.warn("IOException found", e);
+                }
             }
         }
         return sslContext;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/producer/SendMessageContext.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/producer/SendMessageContext.java
@@ -37,7 +37,7 @@ import io.cloudevents.CloudEvent;
 
 public class SendMessageContext extends RetryContext {
 
-    public static Logger logger = LoggerFactory.getLogger("retry");
+    public static final Logger logger = LoggerFactory.getLogger("retry");
 
     private CloudEvent event;
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/producer/SendMessageContext.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/producer/SendMessageContext.java
@@ -37,7 +37,7 @@ import io.cloudevents.CloudEvent;
 
 public class SendMessageContext extends RetryContext {
 
-    public static final Logger logger = LoggerFactory.getLogger("retry");
+    public static Logger logger = LoggerFactory.getLogger("retry");
 
     private CloudEvent event;
 


### PR DESCRIPTION
Fixes #1818 .

**Motivation**

Handled IOException in eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/SSLContextFactory.java


**Modifications**

Enclose inputStream.close() in try-catch block and caught IOException.


**Documentation**

- Does this pull request introduce a new feature? (yes / no) No
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) Not applicable
- If a feature is not applicable for documentation, explain why? Minor issue which comes under code cleanup.

