### PR TITLE
[ISSUE #1684]Field isn't final but should be [EventMeshStartup]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshStartup.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshStartup.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 
 public class EventMeshStartup {
 
-    public static Logger logger = LoggerFactory.getLogger(EventMeshStartup.class);
+    public static final Logger logger = LoggerFactory.getLogger(EventMeshStartup.class);
 
     public static void main(String[] args) throws Exception {
         try {


### PR DESCRIPTION
Fixes #1684.

### Motivation

This static field public but not final, and could be changed by malicious code or by accident from another package. The field could be made final to avoid this vulnerability.


### Modifications

Add final keyword to avoid vulnerability


### Documentation

- Does this pull request introduce a new feature? (yes / no) no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
