### PR TITLE
[ISSUE #1719]Remove unused field

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshTCPServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshTCPServer.java
@@ -130,8 +130,6 @@ public class EventMeshTCPServer extends AbstractRemotingServer {
         this.rateLimiter = rateLimiter;
     }
 
-    private ScheduledFuture<?> tcpRegisterTask;
-
     private RateLimiter rateLimiter;
 
     public EventMeshTCPServer(EventMeshServer eventMeshServer,


### PR DESCRIPTION
Fixes #1719.

### Motivation

Unused field: org.apache.eventmesh.runtime.boot.EventMeshTCPServer.tcpRegisterTask

This field is never used


### Modifications

Remove unused field

### Documentation

- Does this pull request introduce a new feature? (yes / no) no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
