### PR TITLE
[ISSUE #1845]Method makes literal string comparisons passing the literal as an argument

### DIFF
--- a/eventmesh-connector-plugin/eventmesh-connector-knative/src/main/java/org/apache/eventmesh/connector/knative/cloudevent/impl/KnativeBinaryMessageReader.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-knative/src/main/java/org/apache/eventmesh/connector/knative/cloudevent/impl/KnativeBinaryMessageReader.java
@@ -31,7 +31,7 @@ public class KnativeBinaryMessageReader extends BaseGenericBinaryMessageReaderIm
 
     @Override
     protected boolean isContentTypeHeader(String key) {
-        return key.equals(KnativeHeaders.CONTENT_TYPE);
+        return KnativeHeaders.CONTENT_TYPE.equals(key);
     }
 
     @Override


### PR DESCRIPTION
Fixes #1845 .

### Motivation

located at:
org/apache/eventmesh/connector/knative/cloudevent/impl/KnativeBinaryMessageReader.java line 34
explanation：
This line has the form String str = str.equals("someOtherString")
If the string variable str is null, a NullPointerException may occur. if the code is adapted to String str = "someOtherString".equals(str)
That is, if you call equals() on a string literal, passing the variable as an argument, then this exception will not occur because equals() will check for null.



### Modifications

before 
```java
    @Override
    protected boolean isContentTypeHeader(String key) {
        return key.equals(KnativeHeaders.CONTENT_TYPE);
    }
```

after
```java
   @Override
    protected boolean isContentTypeHeader(String key) {
        return KnativeHeaders.CONTENT_TYPE.equals(key);
    }
```



### Documentation

- Does this pull request introduce a new feature?  no






