### PR TITLE
fix #1848：Possible null pointer dereference due to return value of called method [AsyncSubscribe]

### DIFF
--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/sub/cloudevents/AsyncSubscribe.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/sub/cloudevents/AsyncSubscribe.java
@@ -68,6 +68,10 @@ public class AsyncSubscribe implements ReceiveMsgHook<CloudEvent> {
 
     @Override
     public Optional<CloudEvent> handle(CloudEvent msg) {
+        if (msg.getData() == null) {
+            log.warn("receive async msg's data is null.");
+            return Optional.empty();
+        }
         String content = new String(msg.getData().toBytes(), StandardCharsets.UTF_8);
         log.info("receive async msg: {}|{}", msg, content);
         return Optional.empty();


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Cloese #<XXX>`.)
-->

Fixes #1848 .

### Motivation

located at:
org/apache/eventmesh/tcp/demo/sub/cloudevents/AsyncSubscribe.java line 71
Add NPE to check for exceptions.


### Modifications

before:

```java
    @Override
    public Optional<CloudEvent> handle(CloudEvent msg) {
        String content = new String(msg.getData().toBytes(), StandardCharsets.UTF_8);
        log.info("receive async msg: {}|{}", msg, content);
        return Optional.empty();
    }
```
after:
```java
    @Override
    public Optional<CloudEvent> handle(CloudEvent msg) {
        if (msg.getData() == null) {
            log.warn("receive async msg's data is null.");
            return Optional.empty();
        }
        String content = new String(msg.getData().toBytes(), StandardCharsets.UTF_8);
        log.info("receive async msg: {}|{}", msg, content);
        return Optional.empty();
    }
```

