### PR TITLE
[ISSUE #1728] use entrySet replace key set iterator

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalSubscribeEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalSubscribeEventProcessor.java
@@ -47,6 +47,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -233,20 +234,23 @@ public class LocalSubscribeEventProcessor extends AbstractEventProcessor impleme
                         newTopicConf.setIdcUrls(idcUrls);
                         map.put(subTopic.getTopic(), newTopicConf);
                     }
-                    for (String key : map.keySet()) {
-                        if (StringUtils.equals(subTopic.getTopic(), key)) {
-                            ConsumerGroupTopicConf latestTopicConf = new ConsumerGroupTopicConf();
-                            latestTopicConf.setConsumerGroup(consumerGroup);
-                            latestTopicConf.setTopic(subTopic.getTopic());
-                            latestTopicConf.setSubscriptionItem(subTopic);
-                            latestTopicConf.setUrls(new HashSet<>(Arrays.asList(url)));
-
-                            ConsumerGroupTopicConf currentTopicConf = map.get(key);
-                            latestTopicConf.getUrls().addAll(currentTopicConf.getUrls());
-                            latestTopicConf.setIdcUrls(idcUrls);
-
-                            map.put(key, latestTopicConf);
+                    Set<Map.Entry<String, ConsumerGroupTopicConf>> entrySet = map.entrySet();
+                    for (Map.Entry<String, ConsumerGroupTopicConf> set : entrySet) {
+                        if (!StringUtils.equals(subTopic.getTopic(), set.getKey())) {
+                            continue;
                         }
+
+                        ConsumerGroupTopicConf latestTopicConf = new ConsumerGroupTopicConf();
+                        latestTopicConf.setConsumerGroup(consumerGroup);
+                        latestTopicConf.setTopic(subTopic.getTopic());
+                        latestTopicConf.setSubscriptionItem(subTopic);
+                        latestTopicConf.setUrls(new HashSet<>(Arrays.asList(url)));
+
+                        ConsumerGroupTopicConf currentTopicConf = set.getValue();
+                        latestTopicConf.getUrls().addAll(currentTopicConf.getUrls());
+                        latestTopicConf.setIdcUrls(idcUrls);
+
+                        map.put(set.getKey(), latestTopicConf);
                     }
                 }
                 eventMeshHTTPServer.localConsumerGroupMapping.put(consumerGroup, consumerGroupConf);


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Cloese #<XXX>`.)
-->

Fixes #1728.

### Motivation
This method accesses the value of a Map entry, using a key that was retrieved from a keySet iterator. It is more efficient to use an iterator on the entrySet of the map, to avoid the Map.get(key) lookup.



### Modifications
Follow the advice in this issue, we replace key set iteration by using `entrySet`.
What's more, unlike style of proposed method in the issue, we use 'happy path' in the for loop.




### Documentation

- Does this pull request introduce a new feature? (yes / no) No
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) Not applicable
- If a feature is not applicable for documentation, explain why? This is a minor issue that comes under code cleanup.