### PR TITLE
[ISSUE #1565] Add logger to record raw exception information

### DIFF
--- a/eventmesh-connector-plugin/eventmesh-connector-kafka/src/main/java/org/apache/eventmesh/connector/kafka/config/ConfigurationWrapper.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-kafka/src/main/java/org/apache/eventmesh/connector/kafka/config/ConfigurationWrapper.java
@@ -34,9 +34,13 @@ import java.util.Properties;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 @Slf4j
 @UtilityClass
 public class ConfigurationWrapper {
+    public static final Logger logger = LoggerFactory.getLogger(ConfigurationWrapper.class);
 
     private static final Properties properties = new Properties();
 
@@ -59,6 +63,7 @@ public class ConfigurationWrapper {
                 properties.load(resourceAsStream);
             }
         } catch (IOException e) {
+            logger.error("Error while loading from classpath:", e);
             throw new RuntimeException(String.format("Load %s.properties file from classpath error", EventMeshConstants.EVENTMESH_CONF_FILE));
         }
         try {
@@ -71,6 +76,7 @@ public class ConfigurationWrapper {
                 }
             }
         } catch (IOException e) {
+            logger.error("Error while loading from conf home: ", e);
             throw new IllegalArgumentException(String.format("Cannot load %s file from conf", EventMeshConstants.EVENTMESH_CONF_FILE));
         }
     }


### PR DESCRIPTION
Fixes #1565.

**Motivation**

The method catches an exception, and throws a different exception, without incorporating the original exception. Doing so hides the original source of the exception, making debugging and fixing these problems difficult.

**Modifications**

Added logger to record raw exception information.

**Documentation**

- Does this pull request introduce a new feature? (yes / no): No
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented): Not applicable
- If a feature is not applicable for documentation, explain why? Minor issue to help debugging