### PR TITLE
[ISSUE #1566]Added logger to record the catched exception

### DIFF
--- a/eventmesh-connector-plugin/eventmesh-connector-kafka/src/main/java/org/apache/eventmesh/connector/kafka/consumer/ConsumerImpl.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-kafka/src/main/java/org/apache/eventmesh/connector/kafka/consumer/ConsumerImpl.java
@@ -38,7 +38,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.kafka.CloudEventDeserializer;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class ConsumerImpl {
+    public static final Logger logger = LoggerFactory.getLogger(ConsumerImpl.class);
     private final KafkaConsumer<String, CloudEvent> kafkaConsumer;
     private final Properties properties;
     private AtomicBoolean started = new AtomicBoolean(false);
@@ -102,6 +106,7 @@ public class ConsumerImpl {
             List<String> topics = new ArrayList<>(topicsSet);
             this.kafkaConsumer.subscribe(topics);
         } catch (Exception e) {
+            logger.error("Error while subscribing the Kafka consumer to topic: ",e);
             throw new ConnectorRuntimeException(
                 String.format("Kafka consumer can't attach to %s.", topic));
         }
@@ -115,6 +120,7 @@ public class ConsumerImpl {
             List<String> topics = new ArrayList<>(topicsSet);
             this.kafkaConsumer.subscribe(topics);
         } catch (Exception e) {
+            logger.error("Error while unsubscribing the Kafka consumer: ",e);
             throw new ConnectorRuntimeException(String.format("kafka push consumer fails to unsubscribe topic: %s", topic));
         }
     }


### PR DESCRIPTION
Fixes #1566 .

### Motivation
This method catches an exception, and throws a different exception, without incorporating the original exception. Doing so hides the original source of the exception, making debugging and fixing these problems difficult.

### Modifications
Added logger to record raw exception information

### Documentation

- Does this pull request introduce a new feature? (yes / no)No
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)not applicable
- If a feature is not applicable for documentation, explain why?This is a minor issue that helps in debugging.

