### PR TITLE
[ISSUE #1725] use entrySet replace key set iterator

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalUnSubscribeEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalUnSubscribeEventProcessor.java
@@ -176,15 +176,16 @@ public class LocalUnSubscribeEventProcessor extends AbstractEventProcessor imple
                             eventMeshHTTPServer.localConsumerGroupMapping.get(consumerGroup);
                         Map<String, ConsumerGroupTopicConf> map =
                             consumerGroupConf.getConsumerGroupTopicConf();
-                        for (String topicKey : map.keySet()) {
+                        Set<Map.Entry<String, ConsumerGroupTopicConf>> entryMap = map.entrySet();
+                        for (Map.Entry<String, ConsumerGroupTopicConf> entry : entryMap) {
                             // only modify the topic to subscribe
-                            if (StringUtils.equals(unSubTopic, topicKey)) {
+                            if (StringUtils.equals(unSubTopic, entry.getKey())) {
                                 ConsumerGroupTopicConf latestTopicConf =
                                     new ConsumerGroupTopicConf();
                                 latestTopicConf.setConsumerGroup(consumerGroup);
                                 latestTopicConf.setTopic(unSubTopic);
                                 latestTopicConf
-                                    .setSubscriptionItem(map.get(topicKey).getSubscriptionItem());
+                                    .setSubscriptionItem(entry.getValue().getSubscriptionItem());
                                 latestTopicConf.setUrls(clientUrls);
 
                                 latestTopicConf.setIdcUrls(idcUrls);


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-eventmesh/issues/1725.

Motivation
This method accesses the value of a Map entry, using a key that was retrieved from a keySet iterator. It is more efficient to use an iterator on the entrySet of the map, to avoid the Map.get(key) lookup.

Modifications
we replace key set iteration by using entrySet.

Documentation
Does this pull request introduce a new feature? (yes / no) No
If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) Not applicable
If a feature is not applicable for documentation, explain why? This is a minor issue that comes under code cleanup.