### PR TITLE
[ISSUE #1703] add NPE check

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/ReplyMessageProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/ReplyMessageProcessor.java
@@ -152,7 +152,7 @@ public class ReplyMessageProcessor implements HttpRequestProcessor {
             return;
         }
 
-        String content = new String(event.getData().toBytes(), StandardCharsets.UTF_8);
+        String content = event.getData() == null ? "" : new String(event.getData().toBytes(), StandardCharsets.UTF_8);
         if (content.length() > eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshEventSize) {
             httpLogger.error("Event size exceeds the limit: {}",
                 eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshEventSize);
@@ -182,7 +182,7 @@ public class ReplyMessageProcessor implements HttpRequestProcessor {
 
         String origTopic = event.getSubject();
 
-        final String replyMQCluster = event.getExtension(EventMeshConstants.PROPERTY_MESSAGE_CLUSTER).toString();
+        final String replyMQCluster = event.getExtension(EventMeshConstants.PROPERTY_MESSAGE_CLUSTER) == null ? "" : event.getExtension(EventMeshConstants.PROPERTY_MESSAGE_CLUSTER).toString();
         if (!org.apache.commons.lang3.StringUtils.isEmpty(replyMQCluster)) {
             replyTopic = replyMQCluster + "-" + replyTopic;
         } else {


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-eventmesh/issues/1703 .

Motivation
The return value from a method is dereferenced without a null check, and the return value of that method is one that should generally be checked for null. This may lead to a NullPointerException when the code is executed.

Modifications
If we get null, we will return empty string instead of calling String.toString().

Documentation
Does this pull request introduce a new feature? (yes / no) No
If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) Not applicable
If a feature is not applicable for documentation, explain why? This is a minor issue that comes under code cleanup