### PR TITLE
[ISSUE #1724]Replace keySet iterator with entrySet in AsyncHTTPPushRequest

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/push/AsyncHTTPPushRequest.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/push/AsyncHTTPPushRequest.java
@@ -139,10 +139,11 @@ public class AsyncHTTPPushRequest extends AbstractHTTPPushRequest {
             } else {
                 HttpEventWrapper httpEventWrapper = (HttpEventWrapper) protocolTransportObject;
                 Map<String, Object> sysHeaderMap = httpEventWrapper.getSysHeaderMap();
+                Set<Map.Entry<String, Object>> sysHeaderMapEntry = sysHeaderMap.entrySet();
                 content = new String(httpEventWrapper.getBody(), StandardCharsets.UTF_8);
-                for (String header : sysHeaderMap.keySet()) {
-                    if (!builder.containsHeader(header)) {
-                        builder.addHeader(header, sysHeaderMap.get(header).toString());
+                for (Map.Entry<String, Object> header : sysHeaderMapEntry) {
+                    if (!builder.containsHeader(header.getKey())) {
+                        builder.addHeader(header.getKey(), header.getValue().toString());
                     }
                 }
             }


### PR DESCRIPTION
Fixes #1724.

### Motivation

This method accesses the value of a Map entry, using a key that was retrieved from a keySet iterator. It is more efficient to use an iterator on the entrySet of the map, to avoid the Map.get(key) lookup.


### Modifications

Replaced  keySet iterator with entrySet in AsyncHTTPPushRequest

### Documentation

- Does this pull request introduce a new feature? (yes / no) no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
