### PR TITLE
[ISSUE #1958] FIX: Method calls String.format on a static (non parameterized) format string [AbstractProducer]

### DIFF
--- a/eventmesh-connector-plugin/eventmesh-connector-pulsar/src/main/java/org/apache/eventmesh/connector/pulsar/producer/AbstractProducer.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-pulsar/src/main/java/org/apache/eventmesh/connector/pulsar/producer/AbstractProducer.java
@@ -40,9 +40,9 @@ public abstract class AbstractProducer {
 
     ConnectorRuntimeException checkProducerException(CloudEvent cloudEvent, Throwable e) {
         if (cloudEvent.getData() == null) {
-            return new ConnectorRuntimeException(String.format("CloudEvent message data does not exist.", e));
+            return new ConnectorRuntimeException(String.format("CloudEvent message data does not exist, %s", e.getMessage()));
         }
-        return new ConnectorRuntimeException(String.format("Unknown connector runtime exception.", e));
+        return new ConnectorRuntimeException(String.format("Unknown connector runtime exception, %s", e.getMessage()));
     }
 
     public boolean isStarted() {


### PR DESCRIPTION
Fixes #1958 .

### Motivation

Method calls String.format on a static (non parameterized) format string  [AbstractProducer]
located at:
org/apache/eventmesh/connector/pulsar/producer/AbstractProducer.java line 46 and 48.

### Modifications

add the %s string.
