### PR TITLE
[ISSUE #1960] Field isn't final but should be [AsyncSyncRequestInstance]

### DIFF
--- a/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/http/demo/AsyncSyncRequestInstance.java
+++ b/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/http/demo/AsyncSyncRequestInstance.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 
 public class AsyncSyncRequestInstance {
 
-    public static Logger logger = LoggerFactory.getLogger(AsyncSyncRequestInstance.class);
+    public static final Logger logger = LoggerFactory.getLogger(AsyncSyncRequestInstance.class);
 
     public static void main(String[] args) throws Exception {
 


### PR DESCRIPTION
Fixes #1960

### Motivation
the field logger should add final



### Modifications
public static final Logger logger = LoggerFactory.getLogger(AsyncSyncRequestInstance.class);


