### PR TITLE
[ISSUE #1700] add NPE check

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/BatchSendMessageProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/BatchSendMessageProcessor.java
@@ -139,7 +139,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
                 return;
             }
 
-            String content = new String(event.getData().toBytes(), StandardCharsets.UTF_8);
+            String content = event.getData() == null ? "" : new String(event.getData().toBytes(), StandardCharsets.UTF_8);
             if (content.length() > eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshEventSize) {
                 batchMessageLogger.error("Event size exceeds the limit: {}",
                     eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshEventSize);


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-eventmesh/issues/1700 .

Motivation
The return value from a method is dereferenced without a null check, and the return value of that method is one that should generally be checked for null. This may lead to a NullPointerException when the code is executed.

Modifications
If we get null, we will simply return empty string.

Documentation
Does this pull request introduce a new feature? (yes / no) No
If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) Not applicable
If a feature is not applicable for documentation, explain why? This is a minor issue that comes under code cleanup