### PR TITLE
[ISSUE #1966] Replace with Objects.equals()

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/session/Session.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/session/Session.java
@@ -261,13 +261,13 @@ public class Session {
             return false;
         }
         Session session = (Session) o;
-        if (client != null ? !client.equals(session.client) : session.client != null) {
+        if (!Objects.equals(client, session.client)) {
             return false;
         }
-        if (context != null ? !context.equals(session.context) : session.context != null) {
+        if (!Objects.equals(context, session.context)) {
             return false;
         }
-        if (sessionState != null ? !sessionState.equals(session.sessionState) : session.sessionState != null) {
+        if (!Objects.equals(sessionState, session.sessionState)) {
             return false;
         }
         return true;


### PR DESCRIPTION
 Replace with Objects.equals()

ref #1966   Fixes #1966

### Motivation

'context != null ? !context.equals(session.context) : session.context != null' replaceable by 'Objects.equals()' expression.

### Modifications

Replace with Objects.equals()

### Documentation

- Does this pull request introduce a new feature? (yes / no) no
