### PR TITLE
[ISSUE #1969]Drop useless code 

### DIFF
--- a/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperation.java
+++ b/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperation.java
@@ -48,7 +48,6 @@ public class FileWebHookConfigOperation implements WebHookConfigOperation {
     public FileWebHookConfigOperation(Properties properties) throws FileNotFoundException {
         String webHookFilePath = WebHookOperationConstant.getFilePath(properties.getProperty("filePath"));
 
-        assert webHookFilePath != null;
         File webHookFileDir = new File(webHookFilePath);
         if (!webHookFileDir.exists()) {
             webHookFileDir.mkdirs();


### PR DESCRIPTION
Drop useless code  
fix #1969 

### Motivation
Condition 'webHookFilePath != null' is always 'true'
This condition is always true, no need to judge.

### Modifications
Drop useless code  
ref #1969 

### Documentation
* Does this pull request introduce a new feature? (no)