### PR TITLE
[ISSUE #1976]Remove redundant modifiers

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/HttpProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/HttpProcessor.java
@@ -25,7 +25,7 @@ import io.netty.handler.codec.http.HttpResponse;
  */
 public interface HttpProcessor {
 
-    public String[] paths();
+    String[] paths();
 
-    public HttpResponse handler(HttpRequest httpRequest);
+    HttpResponse handler(HttpRequest httpRequest);
 }


### PR DESCRIPTION

Fixes #1976.

Motivation
Modifier 'public' is redundant for interface members. All methods in an interface are implicitly public and abstract.

Modifications
Removed redundant modifiers

Documentation

- Does this pull request introduce a new feature? (yes / no) no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) not applicable
- If a feature is not applicable for documentation, explain why? It is a minute issue which comes under code cleanup
