### PR TITLE
[ISSUE #1992] Possible null pointer dereference due to return value of called method [SendMessageRequestProtocolResolver]

### DIFF
--- a/eventmesh-protocol-plugin/eventmesh-protocol-cloudevents/src/main/java/org/apache/eventmesh/protocol/cloudevents/resolver/http/SendMessageRequestProtocolResolver.java
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-cloudevents/src/main/java/org/apache/eventmesh/protocol/cloudevents/resolver/http/SendMessageRequestProtocolResolver.java
@@ -62,6 +62,10 @@ public class SendMessageRequestProtocolResolver {
 
             CloudEvent event = null;
             if (StringUtils.equals(SpecVersion.V1.toString(), protocolVersion)) {
+                if(EventFormatProvider.getInstance() == null ||
+                        EventFormatProvider.getInstance().resolveFormat(JsonFormat.CONTENT_TYPE) == null){
+                    return null;
+                }
                 event = EventFormatProvider.getInstance().resolveFormat(JsonFormat.CONTENT_TYPE)
                         .deserialize(content.getBytes(StandardCharsets.UTF_8));
                 event = CloudEventBuilder.v1(event)
@@ -81,6 +85,10 @@ public class SendMessageRequestProtocolResolver {
                         .withExtension(SendMessageRequestBody.PRODUCERGROUP, producerGroup)
                         .build();
             } else if (StringUtils.equals(SpecVersion.V03.toString(), protocolVersion)) {
+                if(EventFormatProvider.getInstance() == null ||
+                        EventFormatProvider.getInstance().resolveFormat(JsonFormat.CONTENT_TYPE) == null){
+                    return null;
+                }
                 event = EventFormatProvider.getInstance().resolveFormat(JsonFormat.CONTENT_TYPE)
                         .deserialize(content.getBytes(StandardCharsets.UTF_8));
                 event = CloudEventBuilder.v03(event)

--- a/eventmesh-protocol-plugin/eventmesh-protocol-cloudevents/src/main/java/org/apache/eventmesh/protocol/cloudevents/resolver/http/SendMessageRequestProtocolResolver.java
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-cloudevents/src/main/java/org/apache/eventmesh/protocol/cloudevents/resolver/http/SendMessageRequestProtocolResolver.java
@@ -28,6 +28,7 @@ import org.apache.eventmesh.protocol.api.exception.ProtocolHandleException;
 import org.apache.commons.lang3.StringUtils;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.SpecVersion;
@@ -62,11 +63,7 @@ public class SendMessageRequestProtocolResolver {
 
             CloudEvent event = null;
             if (StringUtils.equals(SpecVersion.V1.toString(), protocolVersion)) {
-                if(EventFormatProvider.getInstance() == null ||
-                        EventFormatProvider.getInstance().resolveFormat(JsonFormat.CONTENT_TYPE) == null){
-                    return null;
-                }
-                event = EventFormatProvider.getInstance().resolveFormat(JsonFormat.CONTENT_TYPE)
+                event = Objects.requireNonNull(EventFormatProvider.getInstance().resolveFormat(JsonFormat.CONTENT_TYPE))
                         .deserialize(content.getBytes(StandardCharsets.UTF_8));
                 event = CloudEventBuilder.v1(event)
                         .withExtension(ProtocolKey.REQUEST_CODE, code)
@@ -85,11 +82,7 @@ public class SendMessageRequestProtocolResolver {
                         .withExtension(SendMessageRequestBody.PRODUCERGROUP, producerGroup)
                         .build();
             } else if (StringUtils.equals(SpecVersion.V03.toString(), protocolVersion)) {
-                if(EventFormatProvider.getInstance() == null ||
-                        EventFormatProvider.getInstance().resolveFormat(JsonFormat.CONTENT_TYPE) == null){
-                    return null;
-                }
-                event = EventFormatProvider.getInstance().resolveFormat(JsonFormat.CONTENT_TYPE)
+                event = Objects.requireNonNull(EventFormatProvider.getInstance().resolveFormat(JsonFormat.CONTENT_TYPE))
                         .deserialize(content.getBytes(StandardCharsets.UTF_8));
                 event = CloudEventBuilder.v03(event)
                         .withExtension(ProtocolKey.REQUEST_CODE, code)


### PR DESCRIPTION
Fixes #1992

### Motivation
Possible null  pointer dereference due to return value of called method [SendMessageRequestProtocolResolver],line 65 and line 84

### Modifications
Add null pointer check






