### PR TITLE
[ISSUE #2022]Use the methods that have been extracted [redis ConfigurationWrapper]

### DIFF
--- a/eventmesh-connector-plugin/eventmesh-connector-redis/src/main/java/org/apache/eventmesh/connector/redis/config/ConfigurationWrapper.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-redis/src/main/java/org/apache/eventmesh/connector/redis/config/ConfigurationWrapper.java
@@ -17,19 +17,15 @@
 
 package org.apache.eventmesh.connector.redis.config;
 
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.eventmesh.common.Constants;
 import org.apache.eventmesh.common.utils.PropertiesUtils;
 
-import org.apache.commons.lang3.StringUtils;
-
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
-
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ConfigurationWrapper {
@@ -67,9 +63,7 @@ public class ConfigurationWrapper {
         }
         try {
             String configPath = Constants.EVENTMESH_CONF_HOME + File.separator + CONF_FILE;
-            if (new File(configPath).exists()) {
-                properties.load(new BufferedReader(new FileReader(configPath)));
-            }
+            PropertiesUtils.loadPropertiesWhenFileExist(properties, configPath);
         } catch (IOException e) {
             log.error(String.format("Cannot load %s file from conf", CONF_FILE), e);
             throw new IllegalArgumentException(String.format("Cannot load %s file from conf", CONF_FILE));


### PR DESCRIPTION
Fixes #2022 .

### Motivation

* Use the methods that have been extracted

### Modifications

* org/apache/eventmesh/connector/redis/config/ConfigurationWrapper.java


