### PR TITLE
[ISSUE #1727]Used entrySet in place of keySet in UnSubscribeProcessor

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/UnSubscribeProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/UnSubscribeProcessor.java
@@ -178,15 +178,15 @@ public class UnSubscribeProcessor implements HttpRequestProcessor {
                                 eventMeshHTTPServer.localConsumerGroupMapping.get(consumerGroup);
                         Map<String, ConsumerGroupTopicConf> map =
                                 consumerGroupConf.getConsumerGroupTopicConf();
-                        for (String topicKey : map.keySet()) {
+                        for (Map.Entry<String, ConsumerGroupTopicConf> topicConf : map.entrySet()) {
                             // only modify the topic to subscribe
-                            if (StringUtils.equals(unSubTopic, topicKey)) {
+                            if (StringUtils.equals(unSubTopic, topicConf.getKey())) {
                                 ConsumerGroupTopicConf latestTopicConf =
                                         new ConsumerGroupTopicConf();
                                 latestTopicConf.setConsumerGroup(consumerGroup);
                                 latestTopicConf.setTopic(unSubTopic);
                                 latestTopicConf
-                                        .setSubscriptionItem(map.get(topicKey).getSubscriptionItem());
+                                        .setSubscriptionItem(topicConf.getValue().getSubscriptionItem());
                                 latestTopicConf.setUrls(clientUrls);
 
                                 latestTopicConf.setIdcUrls(idcUrls);


### PR DESCRIPTION



Fixes #1727 .

### Motivation

This pull request uses entrySet in place of keySet in UnSubscribeProcessor for effective iteration of conf.



### Modifications

*Describe the modifications you've done.*

Used entrySet in place of keySet in UnSubscribeProcessor

### Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? (not applicable)
- If a feature is not applicable for documentation, explain why? This does not change any functionality as it involves only refactoring
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation. Not Applicable
