### PR TITLE
[ISSUE #2056] Use try-with-resources to manage resources

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/RejectClientByIpPortHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/RejectClientByIpPortHandler.java
@@ -54,8 +54,7 @@ public class RejectClientByIpPortHandler implements HttpHandler {
     @Override
     public void handle(HttpExchange httpExchange) throws IOException {
         String result = "";
-        OutputStream out = httpExchange.getResponseBody();
-        try {
+        try (OutputStream out = httpExchange.getResponseBody()) {
             String queryString = httpExchange.getRequestURI().getQuery();
             Map<String, String> queryStringInfo = NetUtils.formData2Dic(queryString);
             String ip = queryStringInfo.get(EventMeshConstants.MANAGE_IP);
@@ -98,14 +97,6 @@ public class RejectClientByIpPortHandler implements HttpHandler {
             out.write(result.getBytes(Constants.DEFAULT_CHARSET));
         } catch (Exception e) {
             logger.error("rejectClientByIpPort fail...", e);
-        } finally {
-            if (out != null) {
-                try {
-                    out.close();
-                } catch (IOException e) {
-                    logger.warn("out close failed...", e);
-                }
-            }
         }
 
     }


### PR DESCRIPTION
Fixes #2056 .

Motivation

Change try-catch-finally to try-with-resource to manage resources in a class.

Modifications

Change try-catch-finally to try-with-resource in the class of org.apache.eventmesh.runtime.admin.handler.RejectClientByIpPortHandler at line 57.

Documentation

Does this pull request introduce a new feature? (yes / no) no
If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
If a feature is not applicable for documentation, explain why?
If a feature is not documented yet in this PR, please create a followup issue for adding the documentation