### PR TITLE
[ISSUE #2160] Method stores return result in local before immediately returning it [ConsumerManager]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/ConsumerManager.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/ConsumerManager.java
@@ -257,8 +257,7 @@ public class ConsumerManager {
      * get consumer
      */
     public ConsumerGroupManager getConsumer(String consumerGroup) {
-        ConsumerGroupManager cgm = consumerTable.get(consumerGroup);
-        return cgm;
+        return consumerTable.get(consumerGroup);
     }
 
     /**


### PR DESCRIPTION
Fixes #2160
 
 Method stores return result in local before immediately returning it [ConsumerManager]       
  