### PR TITLE
[ISSUE #2163]  This method needlessly uses a String literal as a Charset encoding [SendSyncMessageProcessor] 

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendSyncMessageProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendSyncMessageProcessor.java
@@ -281,7 +281,7 @@ public class SendSyncMessageProcessor implements HttpRequestProcessor {
                                         String.valueOf(System.currentTimeMillis()))
                                 .build();
                         final String rtnMsg = new String(Objects.requireNonNull(event.getData()).toBytes(),
-                                EventMeshConstants.DEFAULT_CHARSET);
+                                StandardCharsets.UTF_8);
 
                         HttpCommand succ = asyncContext.getRequest().createHttpCommandResponse(
                                 sendMessageResponseHeader,


### PR DESCRIPTION
fix #2163