### PR TITLE
[ISSUE #2257] remove interface public keywords

### DIFF
--- a/eventmesh-webhook/eventmesh-webhook-api/src/main/java/org/apache/eventmesh/webhook/api/WebHookConfigOperation.java
+++ b/eventmesh-webhook/eventmesh-webhook-api/src/main/java/org/apache/eventmesh/webhook/api/WebHookConfigOperation.java
@@ -24,14 +24,14 @@ import java.util.List;
  */
 public interface WebHookConfigOperation {
 
-    public Integer insertWebHookConfig(WebHookConfig webHookConfig);
+    Integer insertWebHookConfig(WebHookConfig webHookConfig);
 
-    public Integer updateWebHookConfig(WebHookConfig webHookConfig);
+    Integer updateWebHookConfig(WebHookConfig webHookConfig);
 
-    public Integer deleteWebHookConfig(WebHookConfig webHookConfig);
+    Integer deleteWebHookConfig(WebHookConfig webHookConfig);
 
-    public WebHookConfig queryWebHookConfigById(WebHookConfig webHookConfig);
+    WebHookConfig queryWebHookConfigById(WebHookConfig webHookConfig);
 
-    public List<WebHookConfig> queryWebHookConfigByManufacturer(WebHookConfig webHookConfig, Integer pageNum,
-                                                                Integer pageSize);
+    List<WebHookConfig> queryWebHookConfigByManufacturer(WebHookConfig webHookConfig, Integer pageNum,
+            Integer pageSize);
 }


### PR DESCRIPTION


Fixes https://github.com/apache/incubator-eventmesh/issues/2257
### Motivation
Interface methods are public by default, so you can remove the keyword public