### PR TITLE
[ISSUE #2249] 'assertTrue()' can be simplified to 'assertEquals()'

### DIFF
--- a/eventmesh-webhook/eventmesh-webhook-admin/src/test/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperationTest.java
+++ b/eventmesh-webhook/eventmesh-webhook-admin/src/test/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperationTest.java
@@ -56,7 +56,7 @@ public class FileWebHookConfigOperationTest {
             queryConfig.setManufacturerName("github");
             List<WebHookConfig> queryResult = fileWebHookConfigOperation.queryWebHookConfigByManufacturer(queryConfig, 1, 1);
             Assert.assertTrue(Objects.nonNull(queryResult) && queryResult.size() == 1);
-            Assert.assertTrue(queryResult.get(0).getCallbackPath().equals(config.getCallbackPath()));
+            Assert.assertEquals(queryResult.get(0).getCallbackPath(),config.getCallbackPath());
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         } finally {

--- a/eventmesh-webhook/eventmesh-webhook-admin/src/test/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperationTest.java
+++ b/eventmesh-webhook/eventmesh-webhook-admin/src/test/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperationTest.java
@@ -56,7 +56,7 @@ public class FileWebHookConfigOperationTest {
             queryConfig.setManufacturerName("github");
             List<WebHookConfig> queryResult = fileWebHookConfigOperation.queryWebHookConfigByManufacturer(queryConfig, 1, 1);
             Assert.assertTrue(Objects.nonNull(queryResult) && queryResult.size() == 1);
-            Assert.assertEquals(queryResult.get(0).getCallbackPath(),config.getCallbackPath());
+            Assert.assertEquals(queryResult.get(0).getCallbackPath(), config.getCallbackPath());
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         } finally {


### PR DESCRIPTION
Fixes #2249
'assertTrue()' is simplified to 'assertEquals()'