### PR TITLE
[ISSUE #2239] fix BufferedReader doesn't auto-close bug and use UTF-8.

### DIFF
--- a/eventmesh-trace-plugin/eventmesh-trace-pinpoint/src/main/java/org/apache/eventmesh/trace/pinpoint/config/PinpointConfiguration.java
+++ b/eventmesh-trace-plugin/eventmesh-trace-pinpoint/src/main/java/org/apache/eventmesh/trace/pinpoint/config/PinpointConfiguration.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -113,9 +114,10 @@ public final class PinpointConfiguration {
     private static void loadProperties() {
         URL resource = PinpointConfiguration.class.getClassLoader().getResource(CONFIG_FILE);
         if (resource != null) {
-            try (InputStream inputStream = resource.openStream()) {
+            try (InputStream inputStream = resource.openStream();
+                BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
                 if (inputStream.available() > 0) {
-                    properties.load(new BufferedReader(new InputStreamReader(inputStream)));
+                    properties.load(reader);
                 }
             } catch (IOException e) {
                 throw new RuntimeException(String.format("Load %s file from classpath error", CONFIG_FILE));


### PR DESCRIPTION
[ISSUE #2239] BufferedReader creates an IO stream object, does not assign it to any fields, pass it to other methods that might close it, or return it, and does not appear to close the stream on all paths out of the method.