### PR TITLE
[ISSUE #2349] Method encodes String bytes without specifying the character encoding

### DIFF
--- a/eventmesh-connector-plugin/eventmesh-connector-pravega/src/test/java/org/apache/eventmesh/connector/pravega/client/PravegaClientTest.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-pravega/src/test/java/org/apache/eventmesh/connector/pravega/client/PravegaClientTest.java
@@ -27,6 +27,7 @@ import org.apache.eventmesh.api.EventListener;
 import org.apache.eventmesh.connector.pravega.config.PravegaConnectorConfig;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.function.Consumer;
 
 import org.junit.Before;
@@ -160,7 +161,7 @@ public class PravegaClientTest {
             .withType("http_request")
             .withDataContentType("application/json")
             .withSubject("TEST-TOPIC-HTTP-ASYNC")
-            .withData(data.getBytes())
+            .withData(data.getBytes(StandardCharsets.UTF_8))
             .withExtension("reqeventmesh2mqtimestamp", "1659342713460")
             .withExtension("ip", "127.0.0.1:51226")
             .withExtension("idc", "idc")


### PR DESCRIPTION
Fixes #2349

### Motivation

Method encodes String bytes without specifying the character encoding


### Modifications
refactor PravegaClientTest.java line 163

### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? ot documented)

