### PR TITLE
[ISSUE #2341]Method encodes String bytes without specifying the character encoding

### DIFF
--- a/eventmesh-connector-plugin/eventmesh-connector-redis/src/test/java/org/apache/eventmesh/connector/redis/connector/UnitTest.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-redis/src/test/java/org/apache/eventmesh/connector/redis/connector/UnitTest.java
@@ -27,6 +27,7 @@ import org.apache.eventmesh.connector.redis.consumer.RedisConsumerTest;
 import org.apache.eventmesh.connector.redis.producer.RedisProducer;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
@@ -87,7 +88,7 @@ public class UnitTest extends AbstractRedisServer {
                 .withSubject(topic)
                 .withType(String.class.getCanonicalName())
                 .withDataContentType("text/plain")
-                .withData("data".getBytes())
+                .withData("data".getBytes(StandardCharsets.UTF_8))
                 .build();
 
             redisProducer.publish(cloudEvent, new SendCallback() {


### PR DESCRIPTION
Fixes #2341

### Motivation

Method encodes String bytes without specifying the character encoding

### Modifications

refacotr UnitTest.java line 90

### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
