### PR TITLE
[ISSUE #2347]  Method encodes String bytes without specifying the character encoding

### DIFF
--- a/eventmesh-connector-plugin/eventmesh-connector-rabbitmq/src/test/java/org/apache/eventmesh/connector/rabbitmq/consumer/RabbitmqConsumerTest.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-rabbitmq/src/test/java/org/apache/eventmesh/connector/rabbitmq/consumer/RabbitmqConsumerTest.java
@@ -24,6 +24,7 @@ import org.apache.eventmesh.api.exception.OnExceptionContext;
 import org.apache.eventmesh.connector.rabbitmq.RabbitmqServer;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -68,7 +69,7 @@ public class RabbitmqConsumerTest extends RabbitmqServer {
                     .withSubject("topic")
                     .withType(String.class.getCanonicalName())
                     .withDataContentType("text/plain")
-                    .withData("data".getBytes())
+                    .withData("data".getBytes(StandardCharsets.UTF_8))
                     .build();
 
             rabbitmqProducer.publish(cloudEvent, new SendCallback() {


### PR DESCRIPTION

Fixes #2347 .

### Motivation

Method encodes String bytes without specifying the character encoding

### Modifications

refactor RabbitmqProducerTest.java line 71,add character encoding.

### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)

