### PR TITLE
[ISSUE #2346] Method encodes String bytes without specifying the character encoding

### DIFF
--- a/eventmesh-connector-plugin/eventmesh-connector-rabbitmq/src/test/java/org/apache/eventmesh/connector/rabbitmq/cloudevent/RabbitmqCloudEventTest.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-rabbitmq/src/test/java/org/apache/eventmesh/connector/rabbitmq/cloudevent/RabbitmqCloudEventTest.java
@@ -18,6 +18,7 @@
 package org.apache.eventmesh.connector.rabbitmq.cloudevent;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 
 import org.junit.Assert;
@@ -40,7 +41,7 @@ public class RabbitmqCloudEventTest {
                 .withSubject("topic")
                 .withType(String.class.getCanonicalName())
                 .withDataContentType("text/plain")
-                .withData("data".getBytes())
+                .withData("data".getBytes(StandardCharsets.UTF_8))
                 .build();
     }
 


### PR DESCRIPTION

Fixes #2346 .

### Motivation

Method encodes String bytes without specifying the character encoding

### Modifications

refactor eventmesh-connector-plugin/eventmesh-connector-rabbitmq/src/test/java/org/apache/eventmesh/connector/rabbitmq/cloudevent/RabbitmqCloudEventTest.java line 43
add character encoding.

### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)

