### PR TITLE
[ISSUE #2384] Inefficient use of keySet iterator instead of entrySet iterator

### DIFF
--- a/eventmesh-protocol-plugin/eventmesh-protocol-http/src/main/java/org/apache/eventmesh/protocol/http/resolver/HttpRequestProtocolResolver.java
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-http/src/main/java/org/apache/eventmesh/protocol/http/resolver/HttpRequestProtocolResolver.java
@@ -65,15 +65,15 @@ public class HttpRequestProtocolResolver {
                 .withDataContentType(HttpProtocolConstant.DATA_CONTENT_TYPE);
 
             // with extensions
-            for (String extensionKey : sysHeaderMap.keySet()) {
-                if (StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_ID, extensionKey)
-                    || StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_SOURCE, extensionKey)
-                    || StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_TYPE, extensionKey)
-                    || StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_SUBJECT, extensionKey)) {
+            for (Map.Entry<String,Object> extension : sysHeaderMap.entrySet()) {
+                if (StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_ID, extension.getKey())
+                    || StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_SOURCE, extension.getKey())
+                    || StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_TYPE, extension.getKey())
+                    || StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_SUBJECT, extension.getKey())) {
                     continue;
                 }
-                String lowerExtensionKey = extensionKey.toLowerCase();
-                builder.withExtension(lowerExtensionKey, sysHeaderMap.get(extensionKey).toString());
+                String lowerExtensionKey = extension.getKey().toLowerCase();
+                builder.withExtension(lowerExtensionKey, sysHeaderMap.get(extension.getKey()).toString());
             }
 
             byte[] requestBody = httpEventWrapper.getBody();


### PR DESCRIPTION

Fixes #2384 .

### Motivation

Inefficient use of keySet iterator instead of entrySet iterator

### Modifications

refactor eventmesh-protocol-plugin/eventmesh-protocol-http/src/main/java/org/apache/eventmesh/protocol/http/resolver/HttpRequestProtocolResolver.java line 76
use entrySet() repalce keySet()

### Documentation

- Does this pull request introduce a new feature? ( no)
- If yes, how is the feature documented? (not documented)

