### PR TITLE
[ISSUE #2384] Inefficient use of keySet iterator instead of entrySet iterator

### DIFF
--- a/eventmesh-protocol-plugin/eventmesh-protocol-http/src/main/java/org/apache/eventmesh/protocol/http/resolver/HttpRequestProtocolResolver.java
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-http/src/main/java/org/apache/eventmesh/protocol/http/resolver/HttpRequestProtocolResolver.java
@@ -50,26 +50,26 @@ public class HttpRequestProtocolResolver {
             String id = sysHeaderMap.getOrDefault(HttpProtocolConstant.CONSTANTS_KEY_ID, UUID.randomUUID()).toString();
 
             String source =
-                sysHeaderMap.getOrDefault(HttpProtocolConstant.CONSTANTS_KEY_SOURCE, HttpProtocolConstant.CONSTANTS_DEFAULT_SOURCE).toString();
+                    sysHeaderMap.getOrDefault(HttpProtocolConstant.CONSTANTS_KEY_SOURCE, HttpProtocolConstant.CONSTANTS_DEFAULT_SOURCE).toString();
 
             String type = sysHeaderMap.getOrDefault(HttpProtocolConstant.CONSTANTS_KEY_TYPE, HttpProtocolConstant.CONSTANTS_DEFAULT_TYPE).toString();
 
             String subject =
-                sysHeaderMap.getOrDefault(HttpProtocolConstant.CONSTANTS_KEY_SUBJECT, HttpProtocolConstant.CONSTANTS_DEFAULT_SUBJECT).toString();
+                    sysHeaderMap.getOrDefault(HttpProtocolConstant.CONSTANTS_KEY_SUBJECT, HttpProtocolConstant.CONSTANTS_DEFAULT_SUBJECT).toString();
 
             // with attributes
             builder.withId(id)
-                .withType(type)
-                .withSource(URI.create(HttpProtocolConstant.CONSTANTS_KEY_SOURCE + ":" + source))
-                .withSubject(subject)
-                .withDataContentType(HttpProtocolConstant.DATA_CONTENT_TYPE);
+                    .withType(type)
+                    .withSource(URI.create(HttpProtocolConstant.CONSTANTS_KEY_SOURCE + ":" + source))
+                    .withSubject(subject)
+                    .withDataContentType(HttpProtocolConstant.DATA_CONTENT_TYPE);
 
             // with extensions
-            for (Map.Entry<String,Object> extension : sysHeaderMap.entrySet()) {
+            for (Map.Entry<String, Object> extension : sysHeaderMap.entrySet()) {
                 if (StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_ID, extension.getKey())
-                    || StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_SOURCE, extension.getKey())
-                    || StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_TYPE, extension.getKey())
-                    || StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_SUBJECT, extension.getKey())) {
+                        || StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_SOURCE, extension.getKey())
+                        || StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_TYPE, extension.getKey())
+                        || StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_SUBJECT, extension.getKey())) {
                     continue;
                 }
                 String lowerExtensionKey = extension.getKey().toLowerCase();
@@ -79,7 +79,8 @@ public class HttpRequestProtocolResolver {
             byte[] requestBody = httpEventWrapper.getBody();
 
             Map<String, Object> requestBodyMap = JsonUtils.deserialize(new String(requestBody, Constants.DEFAULT_CHARSET),
-                new TypeReference<HashMap<String, Object>>() {});
+                    new TypeReference<HashMap<String, Object>>() {
+                    });
 
             String requestURI = httpEventWrapper.getRequestURI();
 

--- a/eventmesh-protocol-plugin/eventmesh-protocol-http/src/main/java/org/apache/eventmesh/protocol/http/resolver/HttpRequestProtocolResolver.java
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-http/src/main/java/org/apache/eventmesh/protocol/http/resolver/HttpRequestProtocolResolver.java
@@ -65,15 +65,15 @@ public class HttpRequestProtocolResolver {
                 .withDataContentType(HttpProtocolConstant.DATA_CONTENT_TYPE);
 
             // with extensions
-            for (String extensionKey : sysHeaderMap.keySet()) {
-                if (StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_ID, extensionKey)
-                    || StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_SOURCE, extensionKey)
-                    || StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_TYPE, extensionKey)
-                    || StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_SUBJECT, extensionKey)) {
+            for (Map.Entry<String,Object> extension : sysHeaderMap.entrySet()) {
+                if (StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_ID, extension.getKey())
+                    || StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_SOURCE, extension.getKey())
+                    || StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_TYPE, extension.getKey())
+                    || StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_SUBJECT, extension.getKey())) {
                     continue;
                 }
-                String lowerExtensionKey = extensionKey.toLowerCase();
-                builder.withExtension(lowerExtensionKey, sysHeaderMap.get(extensionKey).toString());
+                String lowerExtensionKey = extension.getKey().toLowerCase();
+                builder.withExtension(lowerExtensionKey, sysHeaderMap.get(extension.getKey()).toString());
             }
 
             byte[] requestBody = httpEventWrapper.getBody();

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/RemotingHelper.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/RemotingHelper.java
@@ -19,10 +19,6 @@
 
 package org.apache.eventmesh.runtime.util;
 
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
-
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
@@ -39,9 +35,10 @@ public class RemotingHelper {
             sb.append(e);
 
             StackTraceElement[] stackTrace = e.getStackTrace();
-            if (ArrayUtils.isNotEmpty(stackTrace)) {
+            if (stackTrace != null && stackTrace.length > 0) {
                 StackTraceElement elment = stackTrace[0];
-                sb.append(", ").append(elment);
+                sb.append(", ");
+                sb.append(elment.toString());
             }
         }
 
@@ -63,7 +60,7 @@ public class RemotingHelper {
         SocketAddress remote = channel.remoteAddress();
         final String addr = remote != null ? remote.toString() : "";
 
-        if (StringUtils.isNotBlank(addr)) {
+        if (addr.length() > 0) {
             int index = addr.lastIndexOf("/");
             if (index >= 0) {
                 return addr.substring(index + 1);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/RemotingHelper.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/RemotingHelper.java
@@ -19,6 +19,10 @@
 
 package org.apache.eventmesh.runtime.util;
 
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
@@ -35,10 +39,9 @@ public class RemotingHelper {
             sb.append(e);
 
             StackTraceElement[] stackTrace = e.getStackTrace();
-            if (stackTrace != null && stackTrace.length > 0) {
+            if (ArrayUtils.isNotEmpty(stackTrace)) {
                 StackTraceElement elment = stackTrace[0];
-                sb.append(", ");
-                sb.append(elment.toString());
+                sb.append(", ").append(elment);
             }
         }
 
@@ -60,7 +63,7 @@ public class RemotingHelper {
         SocketAddress remote = channel.remoteAddress();
         final String addr = remote != null ? remote.toString() : "";
 
-        if (addr.length() > 0) {
+        if (StringUtils.isNotBlank(addr)) {
             int index = addr.lastIndexOf("/");
             if (index >= 0) {
                 return addr.substring(index + 1);


### PR DESCRIPTION


Fixes #2384 .

### Motivation


### Modifications

refactor eventmesh-protocol-plugin/eventmesh-protocol-http/src/main/java/org/apache/eventmesh/protocol/http/resolver/HttpRequestProtocolResolver.java line 76

using entrySet() replace keySet() method.




### Documentation

- Does this pull request introduce a new feature? ( no)
- If yes, how is the feature documented? (not documented)
