### PR TITLE
[ISSUE #2383] Method concatenates the result of a toString() call

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/RemotingHelper.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/RemotingHelper.java
@@ -19,14 +19,14 @@
 
 package org.apache.eventmesh.runtime.util;
 
+import org.apache.commons.lang3.ArrayUtils;
+
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
-import org.apache.commons.lang3.ArrayUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.netty.channel.Channel;
+
 
 public class RemotingHelper {
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/RemotingHelper.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/RemotingHelper.java
@@ -22,6 +22,7 @@ package org.apache.eventmesh.runtime.util;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,10 +36,9 @@ public class RemotingHelper {
             sb.append(e);
 
             StackTraceElement[] stackTrace = e.getStackTrace();
-            if (stackTrace != null && stackTrace.length > 0) {
+            if (ArrayUtils.isNotEmpty(stackTrace)) {
                 StackTraceElement elment = stackTrace[0];
-                sb.append(", ");
-                sb.append(elment.toString());
+                sb.append(", ").append(elment);
             }
         }
 


### PR DESCRIPTION

Fixes #2383 .

### Motivation

remove Method concatenates the result of a toString() call

### Modifications

refactor eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/RemotingHelper.java line 41
remove toString() method call.

### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)

