### PR TITLE
[ISSUE #2376] Method calls equals on an enum instance

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/push/MessageHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/push/MessageHandler.java
@@ -37,7 +37,7 @@ import com.google.common.collect.Sets;
 
 public class MessageHandler {
 
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(MessageHandler.class);
 
     private static final ScheduledExecutorService SCHEDULER = ThreadPoolFactory.createSingleScheduledExecutor("eventMesh-pushMsgTimeout-");
 
@@ -66,7 +66,7 @@ public class MessageHandler {
         Set<AbstractPushRequest> waitingRequests4Group = MapUtils.getObject(waitingRequests,
                 handleMsgContext.getConsumerGroup(), Sets.newConcurrentHashSet());
         if (waitingRequests4Group.size() > CONSUMER_GROUP_WAITING_REQUEST_THRESHOLD) {
-            logger.warn("waitingRequests is too many, so reject, this message will be send back to MQ, consumerGroup:{}, threshold:{}",
+            LOGGER.warn("waitingRequests is too many, so reject, this message will be send back to MQ, consumerGroup:{}, threshold:{}",
                     handleMsgContext.getConsumerGroup(), CONSUMER_GROUP_WAITING_REQUEST_THRESHOLD);
             return false;
         }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/push/MessageHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/push/MessageHandler.java
@@ -64,10 +64,10 @@ public class MessageHandler {
 
     public boolean handle(HandleMsgContext handleMsgContext) {
         Set<AbstractPushRequest> waitingRequests4Group = MapUtils.getObject(waitingRequests,
-            handleMsgContext.getConsumerGroup(), Sets.newConcurrentHashSet());
+                handleMsgContext.getConsumerGroup(), Sets.newConcurrentHashSet());
         if (waitingRequests4Group.size() > CONSUMER_GROUP_WAITING_REQUEST_THRESHOLD) {
             logger.warn("waitingRequests is too many, so reject, this message will be send back to MQ, consumerGroup:{}, threshold:{}",
-                handleMsgContext.getConsumerGroup(), CONSUMER_GROUP_WAITING_REQUEST_THRESHOLD);
+                    handleMsgContext.getConsumerGroup(), CONSUMER_GROUP_WAITING_REQUEST_THRESHOLD);
             return false;
         }
 
@@ -84,7 +84,7 @@ public class MessageHandler {
 
     private AbstractPushRequest createGrpcPushRequest(HandleMsgContext handleMsgContext) {
         GrpcType grpcType = handleMsgContext.getGrpcType();
-        if (GrpcType.WEBHOOK.equals(grpcType)) {
+        if (GrpcType.WEBHOOK == grpcType) {
             return new WebhookPushRequest(handleMsgContext, waitingRequests);
         } else {
             return new StreamPushRequest(handleMsgContext, waitingRequests);


### PR DESCRIPTION

Fixes #2376 .

### Motivation

Method calls equals on an enum instance

### Modifications

refactor eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/push/MessageHandler.java line 87.
replace equals method with "==".


### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)

