### PR TITLE
[ISSUE #2374] Method calls equals on an enum instance

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/push/WebhookPushRequest.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/push/WebhookPushRequest.java
@@ -60,9 +60,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
 
 public class WebhookPushRequest extends AbstractPushRequest {
 
-    private final Logger messageLogger = LoggerFactory.getLogger("message");
+    private static final Logger MESSAGE_LOGGER = LoggerFactory.getLogger("message");
 
-    private final Logger cmdLogger = LoggerFactory.getLogger("cmd");
+    private static final Logger CMD_LOGGER = LoggerFactory.getLogger("cmd");
 
     /**
      * Key: idc
@@ -106,7 +106,8 @@ public class WebhookPushRequest extends AbstractPushRequest {
             builder.addHeader(ProtocolKey.REQUEST_CODE, requestCode);
             builder.addHeader(ProtocolKey.LANGUAGE, Constants.LANGUAGE_JAVA);
             builder.addHeader(ProtocolKey.VERSION, ProtocolVersion.V1.getVersion());
-            builder.addHeader(ProtocolKey.EventMeshInstanceKey.EVENTMESHCLUSTER, eventMeshGrpcConfiguration.eventMeshCluster);
+            builder.addHeader(ProtocolKey.EventMeshInstanceKey.EVENTMESHCLUSTER,
+                    eventMeshGrpcConfiguration.eventMeshCluster);
             builder.addHeader(ProtocolKey.EventMeshInstanceKey.EVENTMESHIP, eventMeshGrpcConfiguration.eventMeshIp);
             builder.addHeader(ProtocolKey.EventMeshInstanceKey.EVENTMESHENV, eventMeshGrpcConfiguration.eventMeshEnv);
             builder.addHeader(ProtocolKey.EventMeshInstanceKey.EVENTMESHIDC, eventMeshGrpcConfiguration.eventMeshIDC);
@@ -116,7 +117,7 @@ public class WebhookPushRequest extends AbstractPushRequest {
             builder.addHeader(ProtocolKey.PROTOCOL_DESC, requestHeader.getProtocolDesc());
             builder.addHeader(ProtocolKey.PROTOCOL_VERSION, requestHeader.getProtocolVersion());
             builder.addHeader(ProtocolKey.CONTENT_TYPE, simpleMessage.getPropertiesOrDefault(ProtocolKey.CONTENT_TYPE,
-                Constants.CONTENT_TYPE_CLOUDEVENTS_JSON));
+                    Constants.CONTENT_TYPE_CLOUDEVENTS_JSON));
 
             List<NameValuePair> body = new ArrayList<>();
             body.add(new BasicNameValuePair(PushMessageRequestBody.CONTENT, simpleMessage.getContent()));
@@ -137,18 +138,18 @@ public class WebhookPushRequest extends AbstractPushRequest {
 
             addToWaitingMap(this);
 
-            cmdLogger.info("cmd={}|eventMesh2client|from={}|to={}", requestCode,
+            CMD_LOGGER.info("cmd={}|eventMesh2client|from={}|to={}", requestCode,
                     IPUtils.getLocalAddress(), selectedPushUrl);
 
             try {
                 eventMeshGrpcServer.getHttpClient().execute(builder, handleResponse(selectedPushUrl));
-                messageLogger
+                MESSAGE_LOGGER
                         .info("message|eventMesh2client|url={}|topic={}|bizSeqNo={}|uniqueId={}",
                                 selectedPushUrl, simpleMessage.getTopic(), simpleMessage.getSeqNum(),
                                 simpleMessage.getUniqueId());
             } catch (IOException e) {
                 long cost = System.currentTimeMillis() - lastPushTime;
-                messageLogger.error(
+                MESSAGE_LOGGER.error(
                         "message|eventMesh2client|exception={} |emitter|topic={}|bizSeqNo={}"
                                 + "|uniqueId={}|cost={}", e.getMessage(), simpleMessage.getTopic(),
                         simpleMessage.getSeqNum(), simpleMessage.getUniqueId(), cost, e);
@@ -180,7 +181,7 @@ public class WebhookPushRequest extends AbstractPushRequest {
             //eventMeshHTTPServer.metrics.summaryMetrics.recordHTTPPushTimeCost(cost);
             if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
                 //eventMeshHTTPServer.metrics.summaryMetrics.recordHttpPushMsgFailed();
-                messageLogger.info(
+                MESSAGE_LOGGER.info(
                         "message|eventMesh2client|exception|url={}|topic={}|bizSeqNo={}"
                                 + "|uniqueId={}|cost={}", selectedPushUrl, simpleMessage.getTopic(),
                         simpleMessage.getSeqNum(), simpleMessage.getUniqueId(), cost);
@@ -196,7 +197,7 @@ public class WebhookPushRequest extends AbstractPushRequest {
                     return new Object();
                 }
                 ClientRetCode result = processResponseContent(res, selectedPushUrl);
-                messageLogger.info(
+                MESSAGE_LOGGER.info(
                         "message|eventMesh2client|{}|url={}|topic={}|bizSeqNo={}"
                                 + "|uniqueId={}|cost={}", result, selectedPushUrl, simpleMessage.getTopic(),
                         simpleMessage.getSeqNum(), simpleMessage.getUniqueId(), cost);
@@ -225,7 +226,7 @@ public class WebhookPushRequest extends AbstractPushRequest {
             }
             return ClientRetCode.FAIL;
         } catch (Exception e) {
-            messageLogger.warn("url:{}, bizSeqno:{}, uniqueId:{},  httpResponse:{}", selectedPushUrl,
+            MESSAGE_LOGGER.warn("url:{}, bizSeqno:{}, uniqueId:{},  httpResponse:{}", selectedPushUrl,
                     simpleMessage.getSeqNum(), simpleMessage.getUniqueId(), content);
             return ClientRetCode.FAIL;
         }
@@ -236,27 +237,27 @@ public class WebhookPushRequest extends AbstractPushRequest {
         List<String> localIdcUrl = MapUtils.getObject(urls,
                 eventMeshGrpcConfiguration.eventMeshIDC, null);
         if (CollectionUtils.isNotEmpty(localIdcUrl)) {
-            if (subscriptionMode.equals(SubscriptionMode.CLUSTERING)) {
+            if (subscriptionMode == SubscriptionMode.CLUSTERING) {
                 return Collections.singletonList(localIdcUrl.get((startIdx + retryTimes) % localIdcUrl.size()));
-            } else if (subscriptionMode.equals(SubscriptionMode.BROADCASTING)) {
+            } else if (subscriptionMode == SubscriptionMode.BROADCASTING) {
                 return localIdcUrl;
             } else {
-                messageLogger.error("Invalid Subscription Mode, no message returning back to subscriber.");
+                MESSAGE_LOGGER.error("Invalid Subscription Mode, no message returning back to subscriber.");
                 return Collections.emptyList();
             }
         }
 
         if (CollectionUtils.isNotEmpty(totalUrls)) {
-            if (subscriptionMode.equals(SubscriptionMode.CLUSTERING)) {
+            if (subscriptionMode == SubscriptionMode.CLUSTERING) {
                 return Collections.singletonList(totalUrls.get((startIdx + retryTimes) % totalUrls.size()));
-            } else if (subscriptionMode.equals(SubscriptionMode.BROADCASTING)) {
+            } else if (subscriptionMode == SubscriptionMode.BROADCASTING) {
                 return totalUrls;
             } else {
-                messageLogger.error("Invalid Subscription Mode, no message returning back to subscriber.");
+                MESSAGE_LOGGER.error("Invalid Subscription Mode, no message returning back to subscriber.");
                 return Collections.emptyList();
             }
         }
-        messageLogger.error("No event emitters from subscriber, no message returning.");
+        MESSAGE_LOGGER.error("No event emitters from subscriber, no message returning.");
         return Collections.EMPTY_LIST;
     }
 }


### PR DESCRIPTION

Fixes #2374 .

### Motivation

Method calls equals on an enum instance


### Modifications

refactor eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/push/WebhookPushRequest.java line 239 241 250 252, replace equals method with "==".



### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
