### PR TITLE
[ISSUE #2370] Method calls equals on an enum instance

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/EventMeshTcp2Client.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/EventMeshTcp2Client.java
@@ -44,17 +44,17 @@ import io.netty.channel.ChannelHandlerContext;
 
 public class EventMeshTcp2Client {
 
-    private static final Logger logger = LoggerFactory.getLogger(EventMeshTcp2Client.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(EventMeshTcp2Client.class);
 
-    public static InetSocketAddress serverGoodby2Client(EventMeshTCPServer eventMeshTCPServer, Session session,
+    public static InetSocketAddress serverGoodby2Client(EventMeshTCPServer eventMeshTCPServer,
+                                                        Session session,
                                                         ClientSessionGroupMapping mapping) {
-        logger.info("serverGoodby2Client client[{}]", session.getClient());
+        LOGGER.info("serverGoodby2Client client[{}]", session.getClient());
         try {
             long startTime = System.currentTimeMillis();
             Package msg = new Package();
-            msg.setHeader(
-                    new Header(SERVER_GOODBYE_REQUEST, OPStatus.SUCCESS.getCode(), "graceful normal quit from eventmesh",
-                            null));
+            msg.setHeader(new Header(SERVER_GOODBYE_REQUEST, OPStatus.SUCCESS.getCode(),
+                    "graceful normal quit from eventmesh", null));
 
             eventMeshTCPServer.getScheduler().submit(new Runnable() {
                 @Override
@@ -68,15 +68,13 @@ public class EventMeshTcp2Client {
             closeSessionIfTimeout(eventMeshTCPServer, session, mapping);
             return address;
         } catch (Exception e) {
-            logger.error("exception occur while serverGoodby2Client", e);
+            LOGGER.error("exception occur while serverGoodby2Client", e);
             return null;
         }
     }
 
-    public static InetSocketAddress goodBye2Client(EventMeshTCPServer eventMeshTCPServer,
-                                                   Session session,
-                                                   String errMsg,
-                                                   int eventMeshStatus,
+    public static InetSocketAddress goodBye2Client(EventMeshTCPServer eventMeshTCPServer, Session session,
+                                                   String errMsg, int eventMeshStatus,
                                                    ClientSessionGroupMapping mapping) {
         try {
             long startTime = System.currentTimeMillis();
@@ -94,38 +92,34 @@ public class EventMeshTcp2Client {
 
             return session.getRemoteAddress();
         } catch (Exception e) {
-            logger.error("exception occur while goodbye2client", e);
+            LOGGER.error("exception occur while goodbye2client", e);
             return null;
         }
     }
 
-    public static void goodBye2Client(ChannelHandlerContext ctx,
-                                      String errMsg,
-                                      ClientSessionGroupMapping mapping,
+    public static void goodBye2Client(ChannelHandlerContext ctx, String errMsg, ClientSessionGroupMapping mapping,
                                       EventMeshTcpMonitor eventMeshTcpMonitor) {
         long startTime = System.currentTimeMillis();
         Package pkg = new Package(new Header(SERVER_GOODBYE_REQUEST, OPStatus.FAIL.getCode(), errMsg, null));
         eventMeshTcpMonitor.getTcpSummaryMetrics().getEventMesh2clientMsgNum().incrementAndGet();
-        logger.info("goodBye2Client client[{}]", RemotingHelper.parseChannelRemoteAddr(ctx.channel()));
-        ctx.writeAndFlush(pkg).addListener(
-                new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        Utils.logSucceedMessageFlow(pkg, null, startTime, startTime);
-                        try {
-                            mapping.closeSession(ctx);
-                        } catch (Exception e) {
-                            logger.warn("close session failed!", e);
-                        }
-                    }
+        LOGGER.info("goodBye2Client client[{}]", RemotingHelper.parseChannelRemoteAddr(ctx.channel()));
+        ctx.writeAndFlush(pkg).addListener(new ChannelFutureListener() {
+            @Override
+            public void operationComplete(ChannelFuture future) throws Exception {
+                Utils.logSucceedMessageFlow(pkg, null, startTime, startTime);
+                try {
+                    mapping.closeSession(ctx);
+                } catch (Exception e) {
+                    LOGGER.warn("close session failed!", e);
                 }
-        );
+            }
+        });
     }
 
     public static String redirectClient2NewEventMesh(EventMeshTCPServer eventMeshTCPServer, String newEventMeshIp,
                                                      int port, Session session, ClientSessionGroupMapping mapping) {
-        logger.info("begin to gracefully redirect Client {}, newIPPort[{}]", session.getClient(),
-                newEventMeshIp + ":" + port);
+        LOGGER.info("begin to gracefully redirect Client {}, newIPPort[{}]", session.getClient(), newEventMeshIp + ":"
+                + port);
         try {
             long startTime = System.currentTimeMillis();
 
@@ -142,7 +136,7 @@ public class EventMeshTcp2Client {
             closeSessionIfTimeout(eventMeshTCPServer, session, mapping);
             return session.getRemoteAddress() + "--->" + newEventMeshIp + ":" + port;
         } catch (Exception e) {
-            logger.error("exception occur while redirectClient2NewEventMesh", e);
+            LOGGER.error("exception occur while redirectClient2NewEventMesh", e);
             return null;
         }
     }
@@ -153,12 +147,12 @@ public class EventMeshTcp2Client {
             @Override
             public void run() {
                 try {
-                    if (!session.getSessionState().equals(SessionState.CLOSED)) {
+                    if (session.getSessionState() != SessionState.CLOSED) {
                         mapping.closeSession(session.getContext());
-                        logger.info("closeSessionIfTimeout success, session[{}]", session.getClient());
+                        LOGGER.info("closeSessionIfTimeout success, session[{}]", session.getClient());
                     }
                 } catch (Exception e) {
-                    logger.error("close session failed", e);
+                    LOGGER.error("close session failed", e);
                 }
             }
         }, 30 * 1000, TimeUnit.MILLISECONDS);


### PR DESCRIPTION

Fixes #2370 .

### Motivation
Method calls equals on an enum instance

### Modifications

refactor eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/EventMeshTcp2Client.java line 156,replace equals method with "==".


### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? ( not documented)
