### PR TITLE
[ISSUE #2372] Method calls equals on an enum instance

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/consumer/EventMeshConsumer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/consumer/EventMeshConsumer.java
@@ -217,11 +217,11 @@ public class EventMeshConsumer {
         }
     }
 
-    public void updateOffset(SubscriptionMode subscriptionMode, List<CloudEvent> events,
-                             AbstractContext context) throws Exception {
+    public void updateOffset(SubscriptionMode subscriptionMode, List<CloudEvent> events, AbstractContext context)
+            throws Exception {
         if (SubscriptionMode.CLUSTERING == subscriptionMode) {
             persistentMqConsumer.updateOffset(events, context);
-        } else if (SubscriptionMode.BROADCASTING==subscriptionMode) {
+        } else if (SubscriptionMode.BROADCASTING == subscriptionMode) {
             broadcastMqConsumer.updateOffset(events, context);
         } else {
             LOGGER.error("Subscribe Failed. Incorrect Subscription Mode");
@@ -232,9 +232,8 @@ public class EventMeshConsumer {
     private EventListener createEventListener(SubscriptionMode subscriptionMode) {
         return (event, context) -> {
 
-            event = CloudEventBuilder.from(event)
-                    .withExtension(EventMeshConstants.REQ_MQ2EVENTMESH_TIMESTAMP, String.valueOf(System.currentTimeMillis()))
-                    .build();
+            event = CloudEventBuilder.from(event).withExtension(EventMeshConstants.REQ_MQ2EVENTMESH_TIMESTAMP,
+                    String.valueOf(System.currentTimeMillis())).build();
 
             String topic = event.getSubject();
             Object bizSeqNo = event.getExtension(Constants.PROPERTY_MESSAGE_SEARCH_KEYS);
@@ -258,8 +257,9 @@ public class EventMeshConsumer {
 
             if (topicConfig != null) {
                 GrpcType grpcType = topicConfig.getGrpcType();
-                HandleMsgContext handleMsgContext = new HandleMsgContext(consumerGroup, event, subscriptionMode, grpcType,
-                        eventMeshAsyncConsumeContext.getAbstractContext(), eventMeshGrpcServer, this, topicConfig);
+                HandleMsgContext handleMsgContext = new HandleMsgContext(consumerGroup, event, subscriptionMode,
+                        grpcType, eventMeshAsyncConsumeContext.getAbstractContext(), eventMeshGrpcServer,
+                        this, topicConfig);
 
                 if (messageHandler.handle(handleMsgContext)) {
                     eventMeshAsyncConsumeContext.commit(EventMeshAction.ManualAck);
@@ -283,18 +283,20 @@ public class EventMeshConsumer {
         };
     }
 
-    public void sendMessageBack(String consumerGroup, final CloudEvent event, final String uniqueId, String bizSeqNo) throws Exception {
-        EventMeshProducer producer
-                = eventMeshGrpcServer.getProducerManager().getEventMeshProducer(consumerGroup);
+    public void sendMessageBack(String consumerGroup, final CloudEvent event, final String uniqueId, String bizSeqNo)
+            throws Exception {
+        EventMeshProducer producer = eventMeshGrpcServer.getProducerManager().getEventMeshProducer(consumerGroup);
 
         if (producer == null) {
             if (LOGGER.isWarnEnabled()) {
-                LOGGER.warn("consumer:{} consume fail, sendMessageBack, bizSeqNo:{}, uniqueId:{}", consumerGroup, bizSeqNo, uniqueId);
+                LOGGER.warn("consumer:{} consume fail, sendMessageBack, bizSeqNo:{}, uniqueId:{}", consumerGroup,
+                        bizSeqNo, uniqueId);
             }
             return;
         }
 
-        final SendMessageContext sendMessageBackContext = new SendMessageContext(bizSeqNo, event, producer, eventMeshGrpcServer);
+        final SendMessageContext sendMessageBackContext = new SendMessageContext(bizSeqNo, event, producer,
+                eventMeshGrpcServer);
 
         producer.send(sendMessageBackContext, new SendCallback() {
             @Override
@@ -304,7 +306,8 @@ public class EventMeshConsumer {
             @Override
             public void onException(OnExceptionContext context) {
                 if (LOGGER.isWarnEnabled()) {
-                    LOGGER.warn("consumer:{} consume fail, sendMessageBack, bizSeqNo:{}, uniqueId:{}", consumerGroup, bizSeqNo, uniqueId);
+                    LOGGER.warn("consumer:{} consume fail, sendMessageBack, bizSeqNo:{}, uniqueId:{}", consumerGroup,
+                            bizSeqNo, uniqueId);
                 }
             }
         });

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/consumer/EventMeshConsumer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/consumer/EventMeshConsumer.java
@@ -59,7 +59,7 @@ import io.cloudevents.core.builder.CloudEventBuilder;
 
 public class EventMeshConsumer {
 
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(EventMeshConsumer.class);
 
     private final String consumerGroup;
 
@@ -143,7 +143,7 @@ public class EventMeshConsumer {
         keyValue.put(CONSUMER_GROUP, consumerGroup);
         keyValue.put(EVENT_MESH_IDC, eventMeshGrpcConfiguration.eventMeshIDC);
         keyValue.put(INSTANCE_NAME, EventMeshUtil.buildMeshClientID(consumerGroup,
-            eventMeshGrpcConfiguration.eventMeshCluster));
+                eventMeshGrpcConfiguration.eventMeshCluster));
         persistentMqConsumer.init(keyValue);
         EventListener clusterEventListner = createEventListener(SubscriptionMode.CLUSTERING);
         persistentMqConsumer.registerEventListener(clusterEventListner);
@@ -153,13 +153,13 @@ public class EventMeshConsumer {
         broadcastKeyValue.put(CONSUMER_GROUP, consumerGroup);
         broadcastKeyValue.put(EVENT_MESH_IDC, eventMeshGrpcConfiguration.eventMeshIDC);
         broadcastKeyValue.put(INSTANCE_NAME, EventMeshUtil.buildMeshClientID(consumerGroup,
-            eventMeshGrpcConfiguration.eventMeshCluster));
+                eventMeshGrpcConfiguration.eventMeshCluster));
         broadcastMqConsumer.init(broadcastKeyValue);
         EventListener broadcastEventListner = createEventListener(SubscriptionMode.BROADCASTING);
         broadcastMqConsumer.registerEventListener(broadcastEventListner);
 
         serviceState = ServiceState.INITED;
-        logger.info("EventMeshConsumer [{}] initialized.............", consumerGroup);
+        LOGGER.info("EventMeshConsumer [{}] initialized.............", consumerGroup);
     }
 
     public synchronized void start() throws Exception {
@@ -176,7 +176,7 @@ public class EventMeshConsumer {
         broadcastMqConsumer.start();
 
         serviceState = ServiceState.RUNNING;
-        logger.info("EventMeshConsumer [{}] started..........", consumerGroup);
+        LOGGER.info("EventMeshConsumer [{}] started..........", consumerGroup);
     }
 
     public synchronized void shutdown() throws Exception {
@@ -184,7 +184,9 @@ public class EventMeshConsumer {
         broadcastMqConsumer.shutdown();
 
         serviceState = ServiceState.STOPED;
-        logger.info("EventMeshConsumer [{}] shutdown.........", consumerGroup);
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("EventMeshConsumer [{}] shutdown.........", consumerGroup);
+        }
     }
 
     public ServiceState getStatus() {
@@ -192,12 +194,12 @@ public class EventMeshConsumer {
     }
 
     public void subscribe(String topic, SubscriptionMode subscriptionMode) throws Exception {
-        if (SubscriptionMode.CLUSTERING.equals(subscriptionMode)) {
+        if (SubscriptionMode.CLUSTERING == subscriptionMode) {
             persistentMqConsumer.subscribe(topic);
-        } else if (SubscriptionMode.BROADCASTING.equals(subscriptionMode)) {
+        } else if (SubscriptionMode.BROADCASTING == subscriptionMode) {
             broadcastMqConsumer.subscribe(topic);
         } else {
-            logger.error("Subscribe Failed. Incorrect Subscription Mode");
+            LOGGER.error("Subscribe Failed. Incorrect Subscription Mode");
             throw new Exception("Subscribe Failed. Incorrect Subscription Mode");
         }
     }
@@ -205,24 +207,24 @@ public class EventMeshConsumer {
     public void unsubscribe(Subscription.SubscriptionItem subscriptionItem) throws Exception {
         SubscriptionMode mode = subscriptionItem.getMode();
         String topic = subscriptionItem.getTopic();
-        if (SubscriptionMode.CLUSTERING.equals(mode)) {
+        if (SubscriptionMode.CLUSTERING == mode) {
             persistentMqConsumer.unsubscribe(topic);
-        } else if (SubscriptionMode.BROADCASTING.equals(mode)) {
+        } else if (SubscriptionMode.BROADCASTING == mode) {
             broadcastMqConsumer.unsubscribe(topic);
         } else {
-            logger.error("Unsubscribe Failed. Incorrect Subscription Mode");
+            LOGGER.error("Unsubscribe Failed. Incorrect Subscription Mode");
             throw new Exception("Unsubscribe Failed. Incorrect Subscription Mode");
         }
     }
 
     public void updateOffset(SubscriptionMode subscriptionMode, List<CloudEvent> events,
                              AbstractContext context) throws Exception {
-        if (SubscriptionMode.CLUSTERING.equals(subscriptionMode)) {
+        if (SubscriptionMode.CLUSTERING == subscriptionMode) {
             persistentMqConsumer.updateOffset(events, context);
-        } else if (SubscriptionMode.BROADCASTING.equals(subscriptionMode)) {
+        } else if (SubscriptionMode.BROADCASTING==subscriptionMode) {
             broadcastMqConsumer.updateOffset(events, context);
         } else {
-            logger.error("Subscribe Failed. Incorrect Subscription Mode");
+            LOGGER.error("Subscribe Failed. Incorrect Subscription Mode");
             throw new Exception("Subscribe Failed. Incorrect Subscription Mode");
         }
     }
@@ -231,8 +233,8 @@ public class EventMeshConsumer {
         return (event, context) -> {
 
             event = CloudEventBuilder.from(event)
-                .withExtension(EventMeshConstants.REQ_MQ2EVENTMESH_TIMESTAMP, String.valueOf(System.currentTimeMillis()))
-                .build();
+                    .withExtension(EventMeshConstants.REQ_MQ2EVENTMESH_TIMESTAMP, String.valueOf(System.currentTimeMillis()))
+                    .build();
 
             String topic = event.getSubject();
             Object bizSeqNo = event.getExtension(Constants.PROPERTY_MESSAGE_SEARCH_KEYS);
@@ -241,10 +243,12 @@ public class EventMeshConsumer {
             Object uniqueId = event.getExtension(Constants.RMB_UNIQ_ID);
             String strUniqueId = uniqueId == null ? "" : uniqueId.toString();
 
-            if (logger.isDebugEnabled()) {
-                logger.debug("message|mq2eventMesh|topic={}|msg={}", topic, event);
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("message|mq2eventMesh|topic={}|msg={}", topic, event);
             } else {
-                logger.info("message|mq2eventMesh|topic={}|bizSeqNo={}|uniqueId={}", topic, bizSeqNo, uniqueId);
+                if (LOGGER.isInfoEnabled()) {
+                    LOGGER.info("message|mq2eventMesh|topic={}|bizSeqNo={}|uniqueId={}", topic, bizSeqNo, uniqueId);
+                }
                 eventMeshGrpcServer.getMetricsMonitor().recordReceiveMsgFromQueue();
             }
 
@@ -255,7 +259,7 @@ public class EventMeshConsumer {
             if (topicConfig != null) {
                 GrpcType grpcType = topicConfig.getGrpcType();
                 HandleMsgContext handleMsgContext = new HandleMsgContext(consumerGroup, event, subscriptionMode, grpcType,
-                    eventMeshAsyncConsumeContext.getAbstractContext(), eventMeshGrpcServer, this, topicConfig);
+                        eventMeshAsyncConsumeContext.getAbstractContext(), eventMeshGrpcServer, this, topicConfig);
 
                 if (messageHandler.handle(handleMsgContext)) {
                     eventMeshAsyncConsumeContext.commit(EventMeshAction.ManualAck);
@@ -271,8 +275,8 @@ public class EventMeshConsumer {
                     }
                 }
             } else {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("no active consumer for topic={}|msg={}", topic, event);
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("no active consumer for topic={}|msg={}", topic, event);
                 }
             }
             eventMeshAsyncConsumeContext.commit(EventMeshAction.CommitMessage);
@@ -281,10 +285,12 @@ public class EventMeshConsumer {
 
     public void sendMessageBack(String consumerGroup, final CloudEvent event, final String uniqueId, String bizSeqNo) throws Exception {
         EventMeshProducer producer
-            = eventMeshGrpcServer.getProducerManager().getEventMeshProducer(consumerGroup);
+                = eventMeshGrpcServer.getProducerManager().getEventMeshProducer(consumerGroup);
 
         if (producer == null) {
-            logger.warn("consumer:{} consume fail, sendMessageBack, bizSeqNo:{}, uniqueId:{}", consumerGroup, bizSeqNo, uniqueId);
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn("consumer:{} consume fail, sendMessageBack, bizSeqNo:{}, uniqueId:{}", consumerGroup, bizSeqNo, uniqueId);
+            }
             return;
         }
 
@@ -297,7 +303,9 @@ public class EventMeshConsumer {
 
             @Override
             public void onException(OnExceptionContext context) {
-                logger.warn("consumer:{} consume fail, sendMessageBack, bizSeqNo:{}, uniqueId:{}", consumerGroup, bizSeqNo, uniqueId);
+                if (LOGGER.isWarnEnabled()) {
+                    LOGGER.warn("consumer:{} consume fail, sendMessageBack, bizSeqNo:{}, uniqueId:{}", consumerGroup, bizSeqNo, uniqueId);
+                }
             }
         });
     }


### PR DESCRIPTION

Fixes #2372 .

### Motivation

Method calls equals on an enum instance

### Modifications

refactor eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/EventMeshConsumer.java,replace equals method with '=='.


### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
