### PR TITLE
[ISSUE #2539] Method stores return result in local before immediately returning it [WebHookProtocolAdaptor]

### DIFF
--- a/eventmesh-protocol-plugin/eventmesh-protocol-webhook/src/main/java/org/apache/eventmesh/protocol/webhook/WebHookProtocolAdaptor.java
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-webhook/src/main/java/org/apache/eventmesh/protocol/webhook/WebHookProtocolAdaptor.java
@@ -54,13 +54,12 @@ public class WebHookProtocolAdaptor implements ProtocolAdaptor<WebhookProtocolTr
     }
 
     @Override
-    public List<CloudEvent> toBatchCloudEvent(WebhookProtocolTransportObject protocol) throws ProtocolHandleException {
-        List<CloudEvent> cloudEventList = new ArrayList<CloudEvent>();
-        return cloudEventList;
+    public List<CloudEvent> toBatchCloudEvent(WebhookProtocolTransportObject protocol) {
+        return new ArrayList<>();
     }
 
     @Override
-    public ProtocolTransportObject fromCloudEvent(CloudEvent cloudEvent) throws ProtocolHandleException {
+    public ProtocolTransportObject fromCloudEvent(CloudEvent cloudEvent) {
         final HttpEventWrapper httpEventWrapper = new HttpEventWrapper();
         Map<String, Object> sysHeaderMap = new HashMap<>();
         // ce attributes


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-eventmesh/issues/2539

### Motivation

*Explain the content here.*
*Explain why you want to make the changes and what problem you're trying to solve.*



### Modifications

*Describe the modifications you've done.*



### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
