### PR TITLE
[ISSUE #2534] Method stores return result in local before immediately returning it [BaseRequestBody]

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/http/body/BaseRequestBody.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/http/body/BaseRequestBody.java
@@ -28,7 +28,6 @@ public class BaseRequestBody extends Body {
 
     @Override
     public Map<String, Object> toMap() {
-        Map<String, Object> map = new HashMap<String, Object>();
-        return map;
+        return new HashMap<String, Object>();
     }
 }


### PR DESCRIPTION

Fixes #2534 .

### Motivation

Method stores return result in local before immediately returning it [BaseRequestBody]

### Modifications

refactor eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/http/body/BaseRequestBody.java



### Documentation

- Does this pull request introduce a new feature? ( no)
- If yes, how is the feature documented? (not documented)

