### PR TITLE
[ISSUE #2594]Method passes a simple String.format result to an SLF4J's or Log4j2's format string [EventMeshTcpMonitor]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/metrics/tcp/EventMeshTcpMonitor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/metrics/tcp/EventMeshTcpMonitor.java
@@ -40,6 +40,9 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class EventMeshTcpMonitor {
 
     private final EventMeshTCPServer eventMeshTCPServer;
@@ -52,11 +55,7 @@ public class EventMeshTcpMonitor {
 
     private final Logger appLogger = LoggerFactory.getLogger("appMonitor");
 
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
-
-    private static int delay = 60 * 1000;
-
-    private static int period = 60 * 1000;
+    private static final int period = 60 * 1000;
 
     private static int PRINT_THREADPOOLSTATE_INTERVAL = 1;
 
@@ -76,15 +75,16 @@ public class EventMeshTcpMonitor {
 
     public void init() throws Exception {
         metricsRegistries.forEach(MetricsRegistry::start);
-        logger.info("EventMeshTcpMonitor initialized......");
+        log.info("EventMeshTcpMonitor initialized......");
     }
 
     public void start() throws Exception {
         metricsRegistries.forEach(metricsRegistry -> {
             metricsRegistry.register(tcpSummaryMetrics);
-            logger.info("Register tcpMetrics to " + metricsRegistry.getClass().getName());
+            log.info("Register tcpMetrics to {}", metricsRegistry.getClass().getName());
         });
 
+        int delay = 60 * 1000;
         monitorTpsTask = eventMeshTCPServer.getScheduler().scheduleAtFixedRate((() -> {
             int msgNum = tcpSummaryMetrics.client2eventMeshMsgNum();
             tcpSummaryMetrics.resetClient2EventMeshMsgNum();
@@ -123,48 +123,9 @@ public class EventMeshTcpMonitor {
             }
             tcpSummaryMetrics.setSubTopicNum(topicSet.size());
             tcpSummaryMetrics.setAllConnections(EventMeshTcpConnectionHandler.connections.get());
+            printAppLogger(tcpSummaryMetrics);
 
-            appLogger.info(String.format(
-                MonitorMetricConstants.EVENTMESH_MONITOR_FORMAT_COMMON,
-                EventMeshConstants.PROTOCOL_TCP,
-                MonitorMetricConstants.CLIENT_2_EVENTMESH_TPS,
-                tcpSummaryMetrics.getClient2eventMeshTPS()));
 
-            appLogger.info(String.format(
-                MonitorMetricConstants.EVENTMESH_MONITOR_FORMAT_COMMON,
-                EventMeshConstants.PROTOCOL_TCP,
-                MonitorMetricConstants.EVENTMESH_2_MQ_TPS,
-                tcpSummaryMetrics.getEventMesh2mqTPS()));
-
-            appLogger.info(String.format(
-                MonitorMetricConstants.EVENTMESH_MONITOR_FORMAT_COMMON,
-                EventMeshConstants.PROTOCOL_TCP,
-                MonitorMetricConstants.MQ_2_EVENTMESH_TPS,
-                tcpSummaryMetrics.getMq2eventMeshTPS()));
-
-            appLogger.info(String.format(
-                MonitorMetricConstants.EVENTMESH_MONITOR_FORMAT_COMMON,
-                EventMeshConstants.PROTOCOL_TCP,
-                MonitorMetricConstants.EVENTMESH_2_CLIENT_TPS,
-                tcpSummaryMetrics.getEventMesh2clientTPS()));
-
-            appLogger.info(String.format(
-                MonitorMetricConstants.EVENTMESH_MONITOR_FORMAT_COMMON,
-                EventMeshConstants.PROTOCOL_TCP,
-                MonitorMetricConstants.ALL_TPS,
-                tcpSummaryMetrics.getAllTPS()));
-
-            appLogger.info(String.format(
-                MonitorMetricConstants.EVENTMESH_MONITOR_FORMAT_COMMON,
-                EventMeshConstants.PROTOCOL_TCP,
-                MonitorMetricConstants.CONNECTION,
-                tcpSummaryMetrics.getAllConnections()));
-
-            appLogger.info(String.format(
-                MonitorMetricConstants.EVENTMESH_MONITOR_FORMAT_COMMON,
-                EventMeshConstants.PROTOCOL_TCP,
-                MonitorMetricConstants.SUB_TOPIC_NUM,
-                tcpSummaryMetrics.getSubTopicNum()));
         }), delay, period, TimeUnit.MILLISECONDS);
 
         monitorThreadPoolTask = eventMeshTCPServer.getScheduler().scheduleAtFixedRate(() -> {
@@ -180,7 +141,30 @@ public class EventMeshTcpMonitor {
                 tcpSummaryMetrics.getRetrySize()));
 
         }, 10, PRINT_THREADPOOLSTATE_INTERVAL, TimeUnit.SECONDS);
-        logger.info("EventMeshTcpMonitor started......");
+        log.info("EventMeshTcpMonitor started......");
+    }
+
+    private void printAppLogger(TcpSummaryMetrics tcpSummaryMetrics) {
+        appLogger.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.CLIENT_2_EVENTMESH_TPS,
+            tcpSummaryMetrics.getClient2eventMeshTPS());
+
+        appLogger.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.EVENTMESH_2_MQ_TPS,
+            tcpSummaryMetrics.getEventMesh2mqTPS());
+
+        appLogger.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.MQ_2_EVENTMESH_TPS,
+            tcpSummaryMetrics.getMq2eventMeshTPS());
+
+        appLogger.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.EVENTMESH_2_CLIENT_TPS,
+            tcpSummaryMetrics.getEventMesh2clientTPS());
+
+        appLogger.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.ALL_TPS,
+            tcpSummaryMetrics.getAllTPS());
+
+        appLogger.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.CONNECTION,
+            tcpSummaryMetrics.getAllConnections());
+
+        appLogger.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.SUB_TOPIC_NUM,
+            tcpSummaryMetrics.getSubTopicNum());
     }
 
     public TcpSummaryMetrics getTcpSummaryMetrics() {
@@ -191,6 +175,6 @@ public class EventMeshTcpMonitor {
         monitorTpsTask.cancel(true);
         monitorThreadPoolTask.cancel(true);
         metricsRegistries.forEach(MetricsRegistry::showdown);
-        logger.info("EventMeshTcpMonitor shutdown......");
+        log.info("EventMeshTcpMonitor shutdown......");
     }
 }


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-eventmesh/issues/2594

### Motivation

*Explain the content here.*
*Explain why you want to make the changes and what problem you're trying to solve.*



### Modifications

*Describe the modifications you've done.*



### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
