### PR TITLE
[ISSUE #2527] Method stores return result in local before immediately returning it [RegistryResponse]

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/catalog/protos/RegistryResponse.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/catalog/protos/RegistryResponse.java
@@ -20,15 +20,17 @@
 
 package org.apache.eventmesh.common.protocol.catalog.protos;
 
+import java.util.Objects;
+
 /**
  * Protobuf type {@code eventmesh.catalog.api.protocol.RegistryResponse}
  */
 @SuppressWarnings({"all"})
 public final class RegistryResponse extends
-    com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:eventmesh.catalog.api.protocol.RegistryResponse)
-    RegistryResponseOrBuilder {
-    private static final long serialVersionUID = 0L;
+        com.google.protobuf.GeneratedMessageV3 implements
+        // @@protoc_insertion_point(message_implements:eventmesh.catalog.api.protocol.RegistryResponse)
+        RegistryResponseOrBuilder {
+    private static final long serialVersionUID = 5690543722366991453L;
 
     // Use RegistryResponse.newBuilder() to construct.
     private RegistryResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
@@ -41,7 +43,7 @@ public final class RegistryResponse extends
     @Override
     @SuppressWarnings({"unused"})
     protected Object newInstance(
-        UnusedPrivateParameter unused) {
+            UnusedPrivateParameter unused) {
         return new RegistryResponse();
     }
 
@@ -52,15 +54,15 @@ public final class RegistryResponse extends
     }
 
     private RegistryResponse(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
         this();
-        if (extensionRegistry == null) {
-            throw new NullPointerException();
-        }
+        Objects.requireNonNull(input, "CodedInputStream can not be null");
+        Objects.requireNonNull(extensionRegistry, "ExtensionRegistryLite can not be null");
+
         com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-            com.google.protobuf.UnknownFieldSet.newBuilder();
+                com.google.protobuf.UnknownFieldSet.newBuilder();
         try {
             boolean done = false;
             while (!done) {
@@ -71,7 +73,7 @@ public final class RegistryResponse extends
                         break;
                     default: {
                         if (!parseUnknownField(
-                            input, unknownFields, extensionRegistry, tag)) {
+                                input, unknownFields, extensionRegistry, tag)) {
                             done = true;
                         }
                         break;
@@ -82,7 +84,7 @@ public final class RegistryResponse extends
             throw e.setUnfinishedMessage(this);
         } catch (java.io.IOException e) {
             throw new com.google.protobuf.InvalidProtocolBufferException(
-                e).setUnfinishedMessage(this);
+                    e).setUnfinishedMessage(this);
         } finally {
             this.unknownFields = unknownFields.build();
             makeExtensionsImmutable();
@@ -98,19 +100,18 @@ public final class RegistryResponse extends
     protected FieldAccessorTable
     internalGetFieldAccessorTable() {
         return EventmeshCatalogGrpc.internal_static_eventmesh_catalog_api_protocol_RegistryResponse_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                RegistryResponse.class, Builder.class);
+                .ensureFieldAccessorsInitialized(
+                        RegistryResponse.class, Builder.class);
     }
 
     private byte memoizedIsInitialized = -1;
 
     @Override
     public final boolean isInitialized() {
-        byte isInitialized = memoizedIsInitialized;
-        if (isInitialized == 1) {
+        if (memoizedIsInitialized == 1) {
             return true;
         }
-        if (isInitialized == 0) {
+        if (memoizedIsInitialized == 0) {
             return false;
         }
 
@@ -120,7 +121,7 @@ public final class RegistryResponse extends
 
     @Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
-        throws java.io.IOException {
+            throws java.io.IOException {
         unknownFields.writeTo(output);
     }
 
@@ -134,7 +135,7 @@ public final class RegistryResponse extends
         size = 0;
         size += unknownFields.getSerializedSize();
         memoizedSize = size;
-        return size;
+        return memoizedSize;
     }
 
     @Override
@@ -166,84 +167,84 @@ public final class RegistryResponse extends
     }
 
     public static RegistryResponse parseFrom(
-        java.nio.ByteBuffer data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            java.nio.ByteBuffer data)
+            throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
     }
 
     public static RegistryResponse parseFrom(
-        java.nio.ByteBuffer data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            java.nio.ByteBuffer data,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static RegistryResponse parseFrom(
-        com.google.protobuf.ByteString data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            com.google.protobuf.ByteString data)
+            throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
     }
 
     public static RegistryResponse parseFrom(
-        com.google.protobuf.ByteString data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            com.google.protobuf.ByteString data,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static RegistryResponse parseFrom(byte[] data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
     }
 
     public static RegistryResponse parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            byte[] data,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static RegistryResponse parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
+            throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
-            .parseWithIOException(PARSER, input);
+                .parseWithIOException(PARSER, input);
     }
 
     public static RegistryResponse parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
+            java.io.InputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
-            .parseWithIOException(PARSER, input, extensionRegistry);
+                .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
     public static RegistryResponse parseDelimitedFrom(java.io.InputStream input)
-        throws java.io.IOException {
+            throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
-            .parseDelimitedWithIOException(PARSER, input);
+                .parseDelimitedWithIOException(PARSER, input);
     }
 
     public static RegistryResponse parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
+            java.io.InputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
-            .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+                .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
 
     public static RegistryResponse parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
+            com.google.protobuf.CodedInputStream input)
+            throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
-            .parseWithIOException(PARSER, input);
+                .parseWithIOException(PARSER, input);
     }
 
     public static RegistryResponse parseFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
-            .parseWithIOException(PARSER, input, extensionRegistry);
+                .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
     @Override
@@ -262,23 +263,21 @@ public final class RegistryResponse extends
     @Override
     public Builder toBuilder() {
         return this == DEFAULT_INSTANCE
-            ? new Builder() : new Builder().mergeFrom(this);
+                ? new Builder() : new Builder().mergeFrom(this);
     }
 
     @Override
-    protected Builder newBuilderForType(
-        BuilderParent parent) {
-        Builder builder = new Builder(parent);
-        return builder;
+    protected Builder newBuilderForType(BuilderParent parent) {
+        return new Builder(parent);
     }
 
     /**
      * Protobuf type {@code eventmesh.catalog.api.protocol.RegistryResponse}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:eventmesh.catalog.api.protocol.RegistryResponse)
-        RegistryResponseOrBuilder {
+            com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+            // @@protoc_insertion_point(builder_implements:eventmesh.catalog.api.protocol.RegistryResponse)
+            RegistryResponseOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
             return EventmeshCatalogGrpc.internal_static_eventmesh_catalog_api_protocol_RegistryResponse_descriptor;
@@ -288,8 +287,8 @@ public final class RegistryResponse extends
         protected FieldAccessorTable
         internalGetFieldAccessorTable() {
             return EventmeshCatalogGrpc.internal_static_eventmesh_catalog_api_protocol_RegistryResponse_fieldAccessorTable
-                .ensureFieldAccessorsInitialized(
-                    RegistryResponse.class, Builder.class);
+                    .ensureFieldAccessorsInitialized(
+                            RegistryResponse.class, Builder.class);
         }
 
         // Construct using org.apache.eventmesh.common.protocol.catalog.protos.RegistryResponse.newBuilder()
@@ -298,14 +297,14 @@ public final class RegistryResponse extends
         }
 
         private Builder(
-            BuilderParent parent) {
+                BuilderParent parent) {
             super(parent);
             maybeForceBuilderInitialization();
         }
 
         private void maybeForceBuilderInitialization() {
             if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
+                    .alwaysUseFieldBuilders) {
             }
         }
 
@@ -349,34 +348,34 @@ public final class RegistryResponse extends
 
         @Override
         public Builder setField(
-            com.google.protobuf.Descriptors.FieldDescriptor field,
-            Object value) {
+                com.google.protobuf.Descriptors.FieldDescriptor field,
+                Object value) {
             return super.setField(field, value);
         }
 
         @Override
         public Builder clearField(
-            com.google.protobuf.Descriptors.FieldDescriptor field) {
+                com.google.protobuf.Descriptors.FieldDescriptor field) {
             return super.clearField(field);
         }
 
         @Override
         public Builder clearOneof(
-            com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+                com.google.protobuf.Descriptors.OneofDescriptor oneof) {
             return super.clearOneof(oneof);
         }
 
         @Override
         public Builder setRepeatedField(
-            com.google.protobuf.Descriptors.FieldDescriptor field,
-            int index, Object value) {
+                com.google.protobuf.Descriptors.FieldDescriptor field,
+                int index, Object value) {
             return super.setRepeatedField(field, index, value);
         }
 
         @Override
         public Builder addRepeatedField(
-            com.google.protobuf.Descriptors.FieldDescriptor field,
-            Object value) {
+                com.google.protobuf.Descriptors.FieldDescriptor field,
+                Object value) {
             return super.addRepeatedField(field, value);
         }
 
@@ -406,9 +405,9 @@ public final class RegistryResponse extends
 
         @Override
         public Builder mergeFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
+                com.google.protobuf.CodedInputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws java.io.IOException {
             RegistryResponse parsedMessage = null;
             try {
                 parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
@@ -425,13 +424,13 @@ public final class RegistryResponse extends
 
         @Override
         public final Builder setUnknownFields(
-            final com.google.protobuf.UnknownFieldSet unknownFields) {
+                final com.google.protobuf.UnknownFieldSet unknownFields) {
             return super.setUnknownFields(unknownFields);
         }
 
         @Override
         public final Builder mergeUnknownFields(
-            final com.google.protobuf.UnknownFieldSet unknownFields) {
+                final com.google.protobuf.UnknownFieldSet unknownFields) {
             return super.mergeUnknownFields(unknownFields);
         }
 
@@ -451,12 +450,12 @@ public final class RegistryResponse extends
     }
 
     private static final com.google.protobuf.Parser<RegistryResponse>
-        PARSER = new com.google.protobuf.AbstractParser<RegistryResponse>() {
+            PARSER = new com.google.protobuf.AbstractParser<RegistryResponse>() {
         @Override
         public RegistryResponse parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+                com.google.protobuf.CodedInputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws com.google.protobuf.InvalidProtocolBufferException {
             return new RegistryResponse(input, extensionRegistry);
         }
     };


### PR DESCRIPTION


Fixes #2527 .

### Motivation

Method stores return result in local before immediately returning it [RegistryResponse]

### Modifications

refactor
eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/catalog/protos/RegistryResponse.java

### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
