### PR TITLE
[ISSUE #2526] Method stores return result in local before immediately returning it [RegistryRequest]

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/catalog/protos/RegistryRequest.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/catalog/protos/RegistryRequest.java
@@ -20,15 +20,19 @@
 
 package org.apache.eventmesh.common.protocol.catalog.protos;
 
+import java.util.Objects;
+
+import com.google.protobuf.ByteString;
+
 /**
  * Protobuf type {@code eventmesh.catalog.api.protocol.RegistryRequest}
  */
 @SuppressWarnings({"all"})
 public final class RegistryRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:eventmesh.catalog.api.protocol.RegistryRequest)
-    RegistryRequestOrBuilder {
-    private static final long serialVersionUID = 0L;
+        com.google.protobuf.GeneratedMessageV3 implements
+        // @@protoc_insertion_point(message_implements:eventmesh.catalog.api.protocol.RegistryRequest)
+        RegistryRequestOrBuilder {
+    private static final long serialVersionUID = 3745623108415722309L;
 
     // Use RegistryRequest.newBuilder() to construct.
     private RegistryRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
@@ -43,7 +47,7 @@ public final class RegistryRequest extends
     @Override
     @SuppressWarnings({"unused"})
     protected Object newInstance(
-        UnusedPrivateParameter unused) {
+            UnusedPrivateParameter unused) {
         return new RegistryRequest();
     }
 
@@ -54,15 +58,15 @@ public final class RegistryRequest extends
     }
 
     private RegistryRequest(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
         this();
-        if (extensionRegistry == null) {
-            throw new NullPointerException();
-        }
+        Objects.requireNonNull(input, "CodedInputStream can not be null");
+        Objects.requireNonNull(extensionRegistry, "ExtensionRegistryLite can not be null");
+
         com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-            com.google.protobuf.UnknownFieldSet.newBuilder();
+                com.google.protobuf.UnknownFieldSet.newBuilder();
         try {
             boolean done = false;
             while (!done) {
@@ -72,20 +76,16 @@ public final class RegistryRequest extends
                         done = true;
                         break;
                     case 10: {
-                        String s = input.readStringRequireUtf8();
-
-                        fileName_ = s;
+                        fileName_ = input.readStringRequireUtf8();
                         break;
                     }
                     case 18: {
-                        String s = input.readStringRequireUtf8();
-
-                        definition_ = s;
+                        definition_ = input.readStringRequireUtf8();
                         break;
                     }
                     default: {
                         if (!parseUnknownField(
-                            input, unknownFields, extensionRegistry, tag)) {
+                                input, unknownFields, extensionRegistry, tag)) {
                             done = true;
                         }
                         break;
@@ -96,7 +96,7 @@ public final class RegistryRequest extends
             throw e.setUnfinishedMessage(this);
         } catch (java.io.IOException e) {
             throw new com.google.protobuf.InvalidProtocolBufferException(
-                e).setUnfinishedMessage(this);
+                    e).setUnfinishedMessage(this);
         } finally {
             this.unknownFields = unknownFields.build();
             makeExtensionsImmutable();
@@ -112,12 +112,12 @@ public final class RegistryRequest extends
     protected FieldAccessorTable
     internalGetFieldAccessorTable() {
         return EventmeshCatalogGrpc.internal_static_eventmesh_catalog_api_protocol_RegistryRequest_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                RegistryRequest.class, Builder.class);
+                .ensureFieldAccessorsInitialized(
+                        RegistryRequest.class, Builder.class);
     }
 
     public static final int FILE_NAME_FIELD_NUMBER = 1;
-    private volatile Object fileName_;
+    private volatile String fileName_;
 
     /**
      * <code>string file_name = 1;</code>
@@ -126,16 +126,7 @@ public final class RegistryRequest extends
      */
     @Override
     public String getFileName() {
-        Object ref = fileName_;
-        if (ref instanceof String) {
-            return (String) ref;
-        } else {
-            com.google.protobuf.ByteString bs =
-                (com.google.protobuf.ByteString) ref;
-            String s = bs.toStringUtf8();
-            fileName_ = s;
-            return s;
-        }
+        return fileName_;
     }
 
     /**
@@ -144,22 +135,12 @@ public final class RegistryRequest extends
      * @return The bytes for fileName.
      */
     @Override
-    public com.google.protobuf.ByteString
-    getFileNameBytes() {
-        Object ref = fileName_;
-        if (ref instanceof String) {
-            com.google.protobuf.ByteString b =
-                com.google.protobuf.ByteString.copyFromUtf8(
-                    (String) ref);
-            fileName_ = b;
-            return b;
-        } else {
-            return (com.google.protobuf.ByteString) ref;
-        }
+    public com.google.protobuf.ByteString getFileNameBytes() {
+        return ByteString.copyFromUtf8(fileName_);
     }
 
     public static final int DEFINITION_FIELD_NUMBER = 2;
-    private volatile Object definition_;
+    private volatile String definition_;
 
     /**
      * <code>string definition = 2;</code>
@@ -168,16 +149,7 @@ public final class RegistryRequest extends
      */
     @Override
     public String getDefinition() {
-        Object ref = definition_;
-        if (ref instanceof String) {
-            return (String) ref;
-        } else {
-            com.google.protobuf.ByteString bs =
-                (com.google.protobuf.ByteString) ref;
-            String s = bs.toStringUtf8();
-            definition_ = s;
-            return s;
-        }
+        return definition_;
     }
 
     /**
@@ -188,27 +160,17 @@ public final class RegistryRequest extends
     @Override
     public com.google.protobuf.ByteString
     getDefinitionBytes() {
-        Object ref = definition_;
-        if (ref instanceof String) {
-            com.google.protobuf.ByteString b =
-                com.google.protobuf.ByteString.copyFromUtf8(
-                    (String) ref);
-            definition_ = b;
-            return b;
-        } else {
-            return (com.google.protobuf.ByteString) ref;
-        }
+        return ByteString.copyFromUtf8(definition_);
     }
 
     private byte memoizedIsInitialized = -1;
 
     @Override
     public final boolean isInitialized() {
-        byte isInitialized = memoizedIsInitialized;
-        if (isInitialized == 1) {
+        if (memoizedIsInitialized == 1) {
             return true;
         }
-        if (isInitialized == 0) {
+        if (memoizedIsInitialized == 0) {
             return false;
         }
 
@@ -218,7 +180,7 @@ public final class RegistryRequest extends
 
     @Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
-        throws java.io.IOException {
+            throws java.io.IOException {
         if (!getFileNameBytes().isEmpty()) {
             com.google.protobuf.GeneratedMessageV3.writeString(output, 1, fileName_);
         }
@@ -258,16 +220,13 @@ public final class RegistryRequest extends
         RegistryRequest other = (RegistryRequest) obj;
 
         if (!getFileName()
-            .equals(other.getFileName())) {
+                .equals(other.getFileName())
+                || !getDefinition()
+                .equals(other.getDefinition())
+                || !unknownFields.equals(other.unknownFields)) {
             return false;
         }
-        if (!getDefinition()
-            .equals(other.getDefinition())) {
-            return false;
-        }
-        if (!unknownFields.equals(other.unknownFields)) {
-            return false;
-        }
+
         return true;
     }
 
@@ -288,84 +247,84 @@ public final class RegistryRequest extends
     }
 
     public static RegistryRequest parseFrom(
-        java.nio.ByteBuffer data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            java.nio.ByteBuffer data)
+            throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
     }
 
     public static RegistryRequest parseFrom(
-        java.nio.ByteBuffer data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            java.nio.ByteBuffer data,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static RegistryRequest parseFrom(
-        com.google.protobuf.ByteString data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            com.google.protobuf.ByteString data)
+            throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
     }
 
     public static RegistryRequest parseFrom(
-        com.google.protobuf.ByteString data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            com.google.protobuf.ByteString data,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static RegistryRequest parseFrom(byte[] data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
     }
 
     public static RegistryRequest parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            byte[] data,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static RegistryRequest parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
+            throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
-            .parseWithIOException(PARSER, input);
+                .parseWithIOException(PARSER, input);
     }
 
     public static RegistryRequest parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
+            java.io.InputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
-            .parseWithIOException(PARSER, input, extensionRegistry);
+                .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
     public static RegistryRequest parseDelimitedFrom(java.io.InputStream input)
-        throws java.io.IOException {
+            throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
-            .parseDelimitedWithIOException(PARSER, input);
+                .parseDelimitedWithIOException(PARSER, input);
     }
 
     public static RegistryRequest parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
+            java.io.InputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
-            .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+                .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
 
     public static RegistryRequest parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
+            com.google.protobuf.CodedInputStream input)
+            throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
-            .parseWithIOException(PARSER, input);
+                .parseWithIOException(PARSER, input);
     }
 
     public static RegistryRequest parseFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
-            .parseWithIOException(PARSER, input, extensionRegistry);
+                .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
     @Override
@@ -384,12 +343,12 @@ public final class RegistryRequest extends
     @Override
     public Builder toBuilder() {
         return this == DEFAULT_INSTANCE
-            ? new Builder() : new Builder().mergeFrom(this);
+                ? new Builder() : new Builder().mergeFrom(this);
     }
 
     @Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+            BuilderParent parent) {
         Builder builder = new Builder(parent);
         return builder;
     }
@@ -398,9 +357,9 @@ public final class RegistryRequest extends
      * Protobuf type {@code eventmesh.catalog.api.protocol.RegistryRequest}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:eventmesh.catalog.api.protocol.RegistryRequest)
-        RegistryRequestOrBuilder {
+            com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+            // @@protoc_insertion_point(builder_implements:eventmesh.catalog.api.protocol.RegistryRequest)
+            RegistryRequestOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
             return EventmeshCatalogGrpc.internal_static_eventmesh_catalog_api_protocol_RegistryRequest_descriptor;
@@ -410,8 +369,8 @@ public final class RegistryRequest extends
         protected FieldAccessorTable
         internalGetFieldAccessorTable() {
             return EventmeshCatalogGrpc.internal_static_eventmesh_catalog_api_protocol_RegistryRequest_fieldAccessorTable
-                .ensureFieldAccessorsInitialized(
-                    RegistryRequest.class, Builder.class);
+                    .ensureFieldAccessorsInitialized(
+                            RegistryRequest.class, Builder.class);
         }
 
         // Construct using org.apache.eventmesh.common.protocol.catalog.protos.RegistryRequest.newBuilder()
@@ -419,15 +378,14 @@ public final class RegistryRequest extends
             maybeForceBuilderInitialization();
         }
 
-        private Builder(
-            BuilderParent parent) {
+        private Builder(BuilderParent parent) {
             super(parent);
             maybeForceBuilderInitialization();
         }
 
         private void maybeForceBuilderInitialization() {
             if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
+                    .alwaysUseFieldBuilders) {
             }
         }
 
@@ -477,34 +435,34 @@ public final class RegistryRequest extends
 
         @Override
         public Builder setField(
-            com.google.protobuf.Descriptors.FieldDescriptor field,
-            Object value) {
+                com.google.protobuf.Descriptors.FieldDescriptor field,
+                Object value) {
             return super.setField(field, value);
         }
 
         @Override
         public Builder clearField(
-            com.google.protobuf.Descriptors.FieldDescriptor field) {
+                com.google.protobuf.Descriptors.FieldDescriptor field) {
             return super.clearField(field);
         }
 
         @Override
         public Builder clearOneof(
-            com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+                com.google.protobuf.Descriptors.OneofDescriptor oneof) {
             return super.clearOneof(oneof);
         }
 
         @Override
         public Builder setRepeatedField(
-            com.google.protobuf.Descriptors.FieldDescriptor field,
-            int index, Object value) {
+                com.google.protobuf.Descriptors.FieldDescriptor field,
+                int index, Object value) {
             return super.setRepeatedField(field, index, value);
         }
 
         @Override
         public Builder addRepeatedField(
-            com.google.protobuf.Descriptors.FieldDescriptor field,
-            Object value) {
+                com.google.protobuf.Descriptors.FieldDescriptor field,
+                Object value) {
             return super.addRepeatedField(field, value);
         }
 
@@ -542,9 +500,9 @@ public final class RegistryRequest extends
 
         @Override
         public Builder mergeFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
+                com.google.protobuf.CodedInputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws java.io.IOException {
             RegistryRequest parsedMessage = null;
             try {
                 parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
@@ -559,7 +517,7 @@ public final class RegistryRequest extends
             return this;
         }
 
-        private Object fileName_ = "";
+        private String fileName_ = "";
 
         /**
          * <code>string file_name = 1;</code>
@@ -567,16 +525,7 @@ public final class RegistryRequest extends
          * @return The fileName.
          */
         public String getFileName() {
-            Object ref = fileName_;
-            if (!(ref instanceof String)) {
-                com.google.protobuf.ByteString bs =
-                    (com.google.protobuf.ByteString) ref;
-                String s = bs.toStringUtf8();
-                fileName_ = s;
-                return s;
-            } else {
-                return (String) ref;
-            }
+            return fileName_;
         }
 
         /**
@@ -586,16 +535,7 @@ public final class RegistryRequest extends
          */
         public com.google.protobuf.ByteString
         getFileNameBytes() {
-            Object ref = fileName_;
-            if (ref instanceof String) {
-                com.google.protobuf.ByteString b =
-                    com.google.protobuf.ByteString.copyFromUtf8(
-                        (String) ref);
-                fileName_ = b;
-                return b;
-            } else {
-                return (com.google.protobuf.ByteString) ref;
-            }
+            return ByteString.copyFromUtf8(fileName_);
         }
 
         /**
@@ -605,10 +545,8 @@ public final class RegistryRequest extends
          * @return This builder for chaining.
          */
         public Builder setFileName(
-            String value) {
-            if (value == null) {
-                throw new NullPointerException();
-            }
+                String value) {
+            Objects.requireNonNull(value, "FileName can not be null");
 
             fileName_ = value;
             onChanged();
@@ -634,18 +572,16 @@ public final class RegistryRequest extends
          * @return This builder for chaining.
          */
         public Builder setFileNameBytes(
-            com.google.protobuf.ByteString value) {
-            if (value == null) {
-                throw new NullPointerException();
-            }
+                com.google.protobuf.ByteString value) {
+            Objects.requireNonNull(value, "FileNameBytes can not be null");
             checkByteStringIsUtf8(value);
 
-            fileName_ = value;
+            fileName_ = value.toStringUtf8();
             onChanged();
             return this;
         }
 
-        private Object definition_ = "";
+        private String definition_ = "";
 
         /**
          * <code>string definition = 2;</code>
@@ -653,16 +589,7 @@ public final class RegistryRequest extends
          * @return The definition.
          */
         public String getDefinition() {
-            Object ref = definition_;
-            if (!(ref instanceof String)) {
-                com.google.protobuf.ByteString bs =
-                    (com.google.protobuf.ByteString) ref;
-                String s = bs.toStringUtf8();
-                definition_ = s;
-                return s;
-            } else {
-                return (String) ref;
-            }
+            return definition_;
         }
 
         /**
@@ -672,16 +599,7 @@ public final class RegistryRequest extends
          */
         public com.google.protobuf.ByteString
         getDefinitionBytes() {
-            Object ref = definition_;
-            if (ref instanceof String) {
-                com.google.protobuf.ByteString b =
-                    com.google.protobuf.ByteString.copyFromUtf8(
-                        (String) ref);
-                definition_ = b;
-                return b;
-            } else {
-                return (com.google.protobuf.ByteString) ref;
-            }
+            return ByteString.copyFromUtf8(definition_);
         }
 
         /**
@@ -691,10 +609,8 @@ public final class RegistryRequest extends
          * @return This builder for chaining.
          */
         public Builder setDefinition(
-            String value) {
-            if (value == null) {
-                throw new NullPointerException();
-            }
+                String value) {
+            Objects.requireNonNull(value, "Definition can not be null");
 
             definition_ = value;
             onChanged();
@@ -720,26 +636,24 @@ public final class RegistryRequest extends
          * @return This builder for chaining.
          */
         public Builder setDefinitionBytes(
-            com.google.protobuf.ByteString value) {
-            if (value == null) {
-                throw new NullPointerException();
-            }
+                com.google.protobuf.ByteString value) {
+            Objects.requireNonNull(value, "DefinitionBytes can not be null");
             checkByteStringIsUtf8(value);
 
-            definition_ = value;
+            definition_ = value.toStringUtf8();
             onChanged();
             return this;
         }
 
         @Override
         public final Builder setUnknownFields(
-            final com.google.protobuf.UnknownFieldSet unknownFields) {
+                final com.google.protobuf.UnknownFieldSet unknownFields) {
             return super.setUnknownFields(unknownFields);
         }
 
         @Override
         public final Builder mergeUnknownFields(
-            final com.google.protobuf.UnknownFieldSet unknownFields) {
+                final com.google.protobuf.UnknownFieldSet unknownFields) {
             return super.mergeUnknownFields(unknownFields);
         }
 
@@ -759,12 +673,12 @@ public final class RegistryRequest extends
     }
 
     private static final com.google.protobuf.Parser<RegistryRequest>
-        PARSER = new com.google.protobuf.AbstractParser<RegistryRequest>() {
+            PARSER = new com.google.protobuf.AbstractParser<RegistryRequest>() {
         @Override
         public RegistryRequest parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+                com.google.protobuf.CodedInputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws com.google.protobuf.InvalidProtocolBufferException {
             return new RegistryRequest(input, extensionRegistry);
         }
     };


### PR DESCRIPTION


Fixes #2526 .

### Motivation

Method stores return result in local before immediately returning it [RegistryRequest]


### Modifications

refactor
eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/catalog/protos/RegistryRequest.java


### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
