### PR TITLE
[ISSUE #2601] Method calls equals on an enum instance [MessageTransferTask]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/AbstractTask.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/AbstractTask.java
@@ -28,8 +28,6 @@ import io.netty.channel.ChannelHandlerContext;
 
 public abstract class AbstractTask implements Runnable {
 
-    protected final Logger logger = LoggerFactory.getLogger(this.getClass());
-
     protected Package pkg;
     protected ChannelHandlerContext ctx;
     protected Session session;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/GoodbyeTask.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/GoodbyeTask.java
@@ -29,9 +29,10 @@ import org.apache.eventmesh.runtime.util.Utils;
 
 import java.util.Arrays;
 
-import io.netty.channel.ChannelHandlerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.netty.channel.ChannelHandlerContext;
 
 public class GoodbyeTask extends AbstractTask {
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/GoodbyeTask.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/GoodbyeTask.java
@@ -30,8 +30,12 @@ import org.apache.eventmesh.runtime.util.Utils;
 import java.util.Arrays;
 
 import io.netty.channel.ChannelHandlerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GoodbyeTask extends AbstractTask {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GoodbyeTask.class);
 
     public GoodbyeTask(Package pkg, ChannelHandlerContext ctx, long startTime, EventMeshTCPServer eventMeshTCPServer) {
         super(pkg, ctx, startTime, eventMeshTCPServer);
@@ -43,16 +47,16 @@ public class GoodbyeTask extends AbstractTask {
         Package msg = new Package();
         try {
             if (pkg.getHeader().getCmd() == Command.SERVER_GOODBYE_RESPONSE) {
-                logger.info("client|address={}| has reject ", session.getContext().channel().remoteAddress());
+                LOGGER.info("client|address={}| has reject ", session.getContext().channel().remoteAddress());
             } else {
                 msg.setHeader(
                         new Header(CLIENT_GOODBYE_RESPONSE, OPStatus.SUCCESS.getCode(), OPStatus.SUCCESS.getDesc(),
                                 pkg.getHeader().getSeq()));
             }
         } catch (Exception e) {
-            logger.error("GoodbyeTask failed|user={}|errMsg={}", session.getClient(), e);
-            msg.setHeader(new Header(CLIENT_GOODBYE_RESPONSE, OPStatus.FAIL.getCode(), Arrays.toString(e.getStackTrace()), pkg
-                    .getHeader().getSeq()));
+            LOGGER.error("GoodbyeTask failed|user={}|errMsg={}", session.getClient(), e);
+            msg.setHeader(new Header(CLIENT_GOODBYE_RESPONSE, OPStatus.FAIL.getCode(), Arrays.toString(e.getStackTrace()),
+                    pkg.getHeader().getSeq()));
         } finally {
             this.eventMeshTCPServer.getScheduler().submit(new Runnable() {
                 @Override

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/HeartBeatTask.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/HeartBeatTask.java
@@ -30,9 +30,10 @@ import org.apache.eventmesh.runtime.util.Utils;
 
 import java.util.Objects;
 
-import io.netty.channel.ChannelHandlerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.netty.channel.ChannelHandlerContext;
 
 public class HeartBeatTask extends AbstractTask {
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/HeartBeatTask.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/HeartBeatTask.java
@@ -31,8 +31,12 @@ import org.apache.eventmesh.runtime.util.Utils;
 import java.util.Objects;
 
 import io.netty.channel.ChannelHandlerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HeartBeatTask extends AbstractTask {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HeartBeatTask.class);
 
     public HeartBeatTask(Package pkg, ChannelHandlerContext ctx, long startTime, EventMeshTCPServer eventMeshTCPServer) {
         super(pkg, ctx, startTime, eventMeshTCPServer);
@@ -55,7 +59,7 @@ public class HeartBeatTask extends AbstractTask {
             res.setHeader(new Header(HEARTBEAT_RESPONSE, OPStatus.SUCCESS.getCode(), OPStatus.SUCCESS.getDesc(),
                     pkg.getHeader().getSeq()));
         } catch (Exception e) {
-            logger.error("HeartBeatTask failed|user={}|errMsg={}", Objects.requireNonNull(session).getClient(), e);
+            LOGGER.error("HeartBeatTask failed|user={}|errMsg={}", Objects.requireNonNull(session).getClient(), e);
             res.setHeader(new Header(HEARTBEAT_RESPONSE, OPStatus.FAIL.getCode(), "exception while "
                     + "heartbeating", pkg.getHeader().getSeq()));
         } finally {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/HelloTask.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/HelloTask.java
@@ -45,7 +45,9 @@ import io.netty.channel.ChannelHandlerContext;
 
 public class HelloTask extends AbstractTask {
 
-    private final Logger messageLogger = LoggerFactory.getLogger("message");
+    private static final Logger LOGGER = LoggerFactory.getLogger(HelloTask.class);
+
+    private static final Logger MESSAGE_LOGGER = LoggerFactory.getLogger("message");
 
     public HelloTask(Package pkg, ChannelHandlerContext ctx, long startTime, EventMeshTCPServer eventMeshTCPServer) {
         super(pkg, ctx, startTime, eventMeshTCPServer);
@@ -65,7 +67,7 @@ public class HelloTask extends AbstractTask {
             }
 
             if (eventMeshTCPServer.getEventMeshServer().getServiceState() != ServiceState.RUNNING) {
-                logger.error("server state is not running:{}", eventMeshTCPServer.getEventMeshServer().getServiceState());
+                LOGGER.error("server state is not running:{}", eventMeshTCPServer.getEventMeshServer().getServiceState());
                 throw new Exception("server state is not running, maybe deploying...");
             }
 
@@ -75,7 +77,7 @@ public class HelloTask extends AbstractTask {
                     pkg.getHeader().getSeq()));
             Utils.writeAndFlush(res, startTime, taskExecuteTime, session.getContext(), session);
         } catch (Throwable e) {
-            messageLogger.error("HelloTask failed|address={},errMsg={}", ctx.channel().remoteAddress(), e);
+            MESSAGE_LOGGER.error("HelloTask failed|address={},errMsg={}", ctx.channel().remoteAddress(), e);
             res.setHeader(new Header(HELLO_RESPONSE, OPStatus.FAIL.getCode(), Arrays.toString(e.getStackTrace()), pkg
                     .getHeader().getSeq()));
             ctx.writeAndFlush(res).addListener(
@@ -87,7 +89,7 @@ public class HelloTask extends AbstractTask {
                             } else {
                                 Utils.logSucceedMessageFlow(res, user, startTime, taskExecuteTime);
                             }
-                            logger.warn("HelloTask failed,close session,addr:{}", ctx.channel().remoteAddress());
+                            LOGGER.warn("HelloTask failed,close session,addr:{}", ctx.channel().remoteAddress());
                             eventMeshTCPServer.getClientSessionGroupMapping().closeSession(ctx);
                         }
                     }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/ListenTask.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/ListenTask.java
@@ -24,9 +24,10 @@ import org.apache.eventmesh.common.protocol.tcp.OPStatus;
 import org.apache.eventmesh.common.protocol.tcp.Package;
 import org.apache.eventmesh.runtime.boot.EventMeshTCPServer;
 
-import io.netty.channel.ChannelHandlerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.netty.channel.ChannelHandlerContext;
 
 public class ListenTask extends AbstractTask {
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/ListenTask.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/ListenTask.java
@@ -25,8 +25,12 @@ import org.apache.eventmesh.common.protocol.tcp.Package;
 import org.apache.eventmesh.runtime.boot.EventMeshTCPServer;
 
 import io.netty.channel.ChannelHandlerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ListenTask extends AbstractTask {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ListenTask.class);
 
     public ListenTask(Package pkg, ChannelHandlerContext ctx, long startTime, EventMeshTCPServer eventMeshTCPServer) {
         super(pkg, ctx, startTime, eventMeshTCPServer);
@@ -42,7 +46,7 @@ public class ListenTask extends AbstractTask {
                 eventMeshTCPServer.getClientSessionGroupMapping().readySession(session);
             }
         } catch (Exception e) {
-            logger.error("ListenTask failed|user={}|errMsg={}", session.getClient(), e);
+            LOGGER.error("ListenTask failed|user={}|errMsg={}", session.getClient(), e);
             Integer status = OPStatus.FAIL.getCode();
             header = new Header(LISTEN_RESPONSE, status, e.toString(), pkg.getHeader().getSeq());
         } finally {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/MessageAckTask.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/MessageAckTask.java
@@ -29,7 +29,9 @@ import io.netty.channel.ChannelHandlerContext;
 
 public class MessageAckTask extends AbstractTask {
 
-    private final Logger messageLogger = LoggerFactory.getLogger("message");
+    private static final Logger LOGGER = LoggerFactory.getLogger(MessageAckTask.class);
+
+    private static final Logger MESSAGE_LOGGER = LoggerFactory.getLogger("message");
 
     public MessageAckTask(Package pkg, ChannelHandlerContext ctx, long startTime, EventMeshTCPServer eventMeshTCPServer) {
         super(pkg, ctx, startTime, eventMeshTCPServer);
@@ -42,7 +44,7 @@ public class MessageAckTask extends AbstractTask {
         Command cmd = pkg.getHeader().getCmd();
 
         if (seq == null) {
-            logger.error("MessageAckTask failed, seq cannot be null|user={}", session.getClient());
+            LOGGER.error("MessageAckTask failed, seq cannot be null|user={}", session.getClient());
             return;
         }
         DownStreamMsgContext downStreamMsgContext = session.getPusher().getUnAckMsg().get(seq);
@@ -52,11 +54,11 @@ public class MessageAckTask extends AbstractTask {
             session.getPusher().getUnAckMsg().remove(seq);
         } else {
             if (cmd != Command.RESPONSE_TO_CLIENT_ACK) {
-                logger.warn("MessageAckTask, seq:{}, downStreamMsgContext not in downStreamMap,client:{}",
-                    seq, session.getClient());
+                LOGGER.warn("MessageAckTask, seq:{}, downStreamMsgContext not in downStreamMap,client:{}",
+                        seq, session.getClient());
             }
         }
-        messageLogger.info("pkg|c2eventMesh|cmd={}|seq=[{}]|user={}|wait={}ms|cost={}ms", cmd, seq, session.getClient(),
-            taskExecuteTime - startTime, System.currentTimeMillis() - startTime);
+        MESSAGE_LOGGER.info("pkg|c2eventMesh|cmd={}|seq=[{}]|user={}|wait={}ms|cost={}ms", cmd, seq, session.getClient(),
+                taskExecuteTime - startTime, System.currentTimeMillis() - startTime);
     }
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/RecommendTask.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/RecommendTask.java
@@ -38,7 +38,9 @@ import io.netty.channel.ChannelHandlerContext;
 
 public class RecommendTask extends AbstractTask {
 
-    private final Logger messageLogger = LoggerFactory.getLogger("message");
+    private static final Logger LOGGER = LoggerFactory.getLogger(RecommendTask.class);
+
+    private static final Logger MESSAGE_LOGGER = LoggerFactory.getLogger("message");
 
     public RecommendTask(Package pkg, ChannelHandlerContext ctx, long startTime, EventMeshTCPServer eventMeshTCPServer) {
         super(pkg, ctx, startTime, eventMeshTCPServer);
@@ -61,7 +63,7 @@ public class RecommendTask extends AbstractTask {
                     pkg.getHeader().getSeq()));
             res.setBody(eventMeshRecommendResult);
         } catch (Exception e) {
-            messageLogger.error("RecommendTask failed|address={}|errMsg={}", ctx.channel().remoteAddress(), e);
+            MESSAGE_LOGGER.error("RecommendTask failed|address={}|errMsg={}", ctx.channel().remoteAddress(), e);
             res.setHeader(new Header(RECOMMEND_RESPONSE, OPStatus.FAIL.getCode(), e.toString(), pkg
                     .getHeader().getSeq()));
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/SubscribeTask.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/SubscribeTask.java
@@ -38,7 +38,9 @@ import io.netty.channel.ChannelHandlerContext;
 
 public class SubscribeTask extends AbstractTask {
 
-    private final Logger messageLogger = LoggerFactory.getLogger("message");
+    private static final Logger LOGGER = LoggerFactory.getLogger(SubscribeTask.class);
+
+    private static final Logger MESSAGE_LOGGER = LoggerFactory.getLogger("message");
 
     public SubscribeTask(Package pkg, ChannelHandlerContext ctx, long startTime, EventMeshTCPServer eventMeshTCPServer) {
         super(pkg, ctx, startTime, eventMeshTCPServer);
@@ -69,12 +71,12 @@ public class SubscribeTask extends AbstractTask {
             }
             synchronized (session) {
                 session.subscribe(subscriptionItems);
-                messageLogger.info("SubscribeTask succeed|user={}|topics={}", session.getClient(), subscriptionItems);
+                MESSAGE_LOGGER.info("SubscribeTask succeed|user={}|topics={}", session.getClient(), subscriptionItems);
             }
             msg.setHeader(new Header(Command.SUBSCRIBE_RESPONSE, OPStatus.SUCCESS.getCode(), OPStatus.SUCCESS.getDesc(),
                     pkg.getHeader().getSeq()));
         } catch (Exception e) {
-            messageLogger.error("SubscribeTask failed|user={}|errMsg={}", session.getClient(), e);
+            MESSAGE_LOGGER.error("SubscribeTask failed|user={}|errMsg={}", session.getClient(), e);
             msg.setHeader(new Header(Command.SUBSCRIBE_RESPONSE, OPStatus.FAIL.getCode(), e.toString(), pkg.getHeader()
                     .getSeq()));
         } finally {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/UnSubscribeTask.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/UnSubscribeTask.java
@@ -38,7 +38,9 @@ import io.netty.channel.ChannelHandlerContext;
 
 public class UnSubscribeTask extends AbstractTask {
 
-    private final Logger messageLogger = LoggerFactory.getLogger("message");
+    private static final Logger LOGGER = LoggerFactory.getLogger(UnSubscribeTask.class);
+
+    private static final Logger MESSAGE_LOGGER = LoggerFactory.getLogger("message");
 
     public UnSubscribeTask(Package pkg, ChannelHandlerContext ctx, long startTime, EventMeshTCPServer eventMeshTCPServer) {
         super(pkg, ctx, startTime, eventMeshTCPServer);
@@ -56,13 +58,13 @@ public class UnSubscribeTask extends AbstractTask {
                         topics.add(entry.getValue());
                     }
                     session.unsubscribe(topics);
-                    messageLogger.info("UnSubscriberTask succeed|user={}|topics={}", session.getClient(), topics);
+                    MESSAGE_LOGGER.info("UnSubscriberTask succeed|user={}|topics={}", session.getClient(), topics);
                 }
             }
             msg.setHeader(new Header(Command.UNSUBSCRIBE_RESPONSE, OPStatus.SUCCESS.getCode(), OPStatus.SUCCESS.getDesc(), pkg.getHeader()
                     .getSeq()));
         } catch (Exception e) {
-            messageLogger.error("UnSubscribeTask failed|user={}|errMsg={}", session.getClient(), e);
+            MESSAGE_LOGGER.error("UnSubscribeTask failed|user={}|errMsg={}", session.getClient(), e);
             msg.setHeader(new Header(Command.UNSUBSCRIBE_RESPONSE, OPStatus.FAIL.getCode(), "exception while "
                     +
                     "unSubscribing", pkg.getHeader().getSeq()));


### PR DESCRIPTION

Fixes #2601 .

### Motivation

Method calls equals on an enum instance [MessageTransferTask]

### Modifications

refactor
eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/MessageTransferTask.java AbstractTask.java and sub Classes.



### Documentation

- Does this pull request introduce a new feature? ( no)
- If yes, how is the feature documented? (not documented)