### PR TITLE
[ISSUE #2598] This method needlessly uses a String literal as a Charset encoding [HttpTinyClient]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/HttpTinyClient.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/HttpTinyClient.java
@@ -26,8 +26,10 @@ import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 public class HttpTinyClient {
 
@@ -107,7 +109,7 @@ public class HttpTinyClient {
             conn.setDoInput(true);
             setHeaders(conn, headers, encoding);
 
-            conn.getOutputStream().write(encodedContent.getBytes(EventMeshConstants.DEFAULT_CHARSET));
+            conn.getOutputStream().write(Objects.requireNonNull(encodedContent).getBytes(StandardCharsets.UTF_8));
 
             int respCode = conn.getResponseCode();
             String resp = null;
@@ -126,8 +128,8 @@ public class HttpTinyClient {
     }
 
     public static class HttpResult {
-        private final int code;
-        private final String content;
+        private final transient int code;
+        private final transient String content;
 
         public HttpResult(int code, String content) {
             this.code = code;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/HttpTinyClient.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/HttpTinyClient.java
@@ -112,13 +112,9 @@ public class HttpTinyClient {
             conn.getOutputStream().write(Objects.requireNonNull(encodedContent).getBytes(StandardCharsets.UTF_8));
 
             int respCode = conn.getResponseCode();
-            String resp = null;
+            String resp = HttpURLConnection.HTTP_OK == respCode ? IOUtils.toString(conn.getInputStream(), encoding)
+                    : IOUtils.toString(conn.getErrorStream(), encoding);
 
-            if (HttpURLConnection.HTTP_OK == respCode) {
-                resp = IOUtils.toString(conn.getInputStream(), encoding);
-            } else {
-                resp = IOUtils.toString(conn.getErrorStream(), encoding);
-            }
             return new HttpResult(respCode, resp);
         } finally {
             if (null != conn) {


### PR DESCRIPTION

Fixes #2598 .

### Motivation

This method needlessly uses a String literal as a Charset encoding [HttpTinyClient]

### Modifications

refactor eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/HttpTinyClient.java


### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
