### PR TITLE
[ISSUE #2596] Method specifies an unrelated class when allocating a Logger [AbstractPushRequest] 

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/push/AbstractPushRequest.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/push/AbstractPushRequest.java
@@ -42,10 +42,12 @@ import io.cloudevents.CloudEvent;
 
 import com.google.common.collect.Sets;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-@Slf4j
 public abstract class AbstractPushRequest extends RetryContext {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractPushRequest.class);
 
     protected EventMeshGrpcServer eventMeshGrpcServer;
     protected long createTime = System.currentTimeMillis();
@@ -84,7 +86,7 @@ public abstract class AbstractPushRequest extends RetryContext {
             ProtocolTransportObject protocolTransportObject = protocolAdaptor.fromCloudEvent(cloudEvent);
             return ((SimpleMessageWrapper) protocolTransportObject).getMessage();
         } catch (Exception e) {
-            log.error("Error in getting EventMeshMessage from CloudEvent", e);
+            LOGGER.error("Error in getting EventMeshMessage from CloudEvent", e);
             return null;
         }
     }
@@ -95,7 +97,7 @@ public abstract class AbstractPushRequest extends RetryContext {
             ProtocolAdaptor<ProtocolTransportObject> protocolAdaptor = ProtocolPluginFactory.getProtocolAdaptor(protocolType);
             return protocolAdaptor.toCloudEvent(new SimpleMessageWrapper(simpleMessage));
         } catch (Exception e) {
-            log.error("Error in getting CloudEvent from EventMeshMessage", e);
+            LOGGER.error("Error in getting CloudEvent from EventMeshMessage", e);
             return null;
         }
     }
@@ -128,7 +130,7 @@ public abstract class AbstractPushRequest extends RetryContext {
             try {
                 eventMeshConsumer.updateOffset(subscriptionMode, Collections.singletonList(event), context);
             } catch (Exception e) {
-                log.error("Error in updating offset in EventMeshConsumer", e);
+                LOGGER.error("Error in updating offset in EventMeshConsumer", e);
             }
         }
     }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/push/AbstractPushRequest.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/push/AbstractPushRequest.java
@@ -38,12 +38,12 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.cloudevents.CloudEvent;
 
 import com.google.common.collect.Sets;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public abstract class AbstractPushRequest extends RetryContext {
 


### PR DESCRIPTION

Fixes #2596 .

### Motivation

Method specifies an unrelated class when allocating a Logger [AbstractPushRequest] 


### Modifications

refactor located at:
eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/push/AbstractPushRequest.java


### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)