### PR TITLE
[ISSUE #2595] Method specifies an unrelated class when allocating a Logger [HeartbeatService]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/service/HeartbeatService.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/service/HeartbeatService.java
@@ -34,22 +34,22 @@ import io.grpc.stub.StreamObserver;
 
 public class HeartbeatService extends HeartbeatServiceGrpc.HeartbeatServiceImplBase {
 
-    private final Logger logger = LoggerFactory.getLogger(ProducerService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HeartbeatService.class);
 
-    private final EventMeshGrpcServer eventMeshGrpcServer;
+    private final transient EventMeshGrpcServer eventMeshGrpcServer;
 
-    private final ThreadPoolExecutor threadPoolExecutor;
+    private final transient ThreadPoolExecutor threadPoolExecutor;
 
-    public HeartbeatService(EventMeshGrpcServer eventMeshGrpcServer,
-                            ThreadPoolExecutor threadPoolExecutor) {
+    public HeartbeatService(final EventMeshGrpcServer eventMeshGrpcServer,
+                            final ThreadPoolExecutor threadPoolExecutor) {
         this.eventMeshGrpcServer = eventMeshGrpcServer;
         this.threadPoolExecutor = threadPoolExecutor;
     }
 
     public void heartbeat(Heartbeat request, StreamObserver<Response> responseObserver) {
-        logger.info("cmd={}|{}|client2eventMesh|from={}|to={}",
-            "heartbeat", EventMeshConstants.PROTOCOL_GRPC,
-            request.getHeader().getIp(), eventMeshGrpcServer.getEventMeshGrpcConfiguration().eventMeshIp);
+        LOGGER.info("cmd={}|{}|client2eventMesh|from={}|to={}",
+                "heartbeat", EventMeshConstants.PROTOCOL_GRPC, request.getHeader().getIp(),
+                eventMeshGrpcServer.getEventMeshGrpcConfiguration().eventMeshIp);
 
         EventEmitter<Response> emitter = new EventEmitter<>(responseObserver);
         threadPoolExecutor.submit(() -> {
@@ -57,8 +57,8 @@ public class HeartbeatService extends HeartbeatServiceGrpc.HeartbeatServiceImplB
             try {
                 heartbeatProcessor.process(request, emitter);
             } catch (Exception e) {
-                logger.error("Error code {}, error message {}", StatusCode.EVENTMESH_HEARTBEAT_ERR.getRetCode(),
-                    StatusCode.EVENTMESH_HEARTBEAT_ERR.getErrMsg(), e);
+                LOGGER.error("Error code {}, error message {}", StatusCode.EVENTMESH_HEARTBEAT_ERR.getRetCode(),
+                        StatusCode.EVENTMESH_HEARTBEAT_ERR.getErrMsg(), e);
                 ServiceUtils.sendRespAndDone(StatusCode.EVENTMESH_HEARTBEAT_ERR, e.getMessage(), emitter);
             }
         });


### PR DESCRIPTION

Fixes #2595 .

### Motivation

Method specifies an unrelated class when allocating a Logger [HeartbeatService]


### Modifications

refactor 
eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/service/HeartbeatService.java


### Documentation

- Does this pull request introduce a new feature? ( no)
- If yes, how is the feature documented? (not documented)
