### PR TITLE
[ISSUE #2629]HttpRequestProtocolResolver pmdTest warn

### DIFF
--- a/eventmesh-protocol-plugin/eventmesh-protocol-http/src/main/java/org/apache/eventmesh/protocol/http/resolver/HttpRequestProtocolResolver.java
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-http/src/main/java/org/apache/eventmesh/protocol/http/resolver/HttpRequestProtocolResolver.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
@@ -49,13 +50,14 @@ public class HttpRequestProtocolResolver {
 
             String id = sysHeaderMap.getOrDefault(HttpProtocolConstant.CONSTANTS_KEY_ID, UUID.randomUUID()).toString();
 
-            String source =
-                    sysHeaderMap.getOrDefault(HttpProtocolConstant.CONSTANTS_KEY_SOURCE, HttpProtocolConstant.CONSTANTS_DEFAULT_SOURCE).toString();
+            String source = sysHeaderMap.getOrDefault(HttpProtocolConstant.CONSTANTS_KEY_SOURCE,
+                    HttpProtocolConstant.CONSTANTS_DEFAULT_SOURCE).toString();
 
-            String type = sysHeaderMap.getOrDefault(HttpProtocolConstant.CONSTANTS_KEY_TYPE, HttpProtocolConstant.CONSTANTS_DEFAULT_TYPE).toString();
+            String type = sysHeaderMap.getOrDefault(HttpProtocolConstant.CONSTANTS_KEY_TYPE,
+                    HttpProtocolConstant.CONSTANTS_DEFAULT_TYPE).toString();
 
-            String subject =
-                    sysHeaderMap.getOrDefault(HttpProtocolConstant.CONSTANTS_KEY_SUBJECT, HttpProtocolConstant.CONSTANTS_DEFAULT_SUBJECT).toString();
+            String subject = sysHeaderMap.getOrDefault(HttpProtocolConstant.CONSTANTS_KEY_SUBJECT,
+                    HttpProtocolConstant.CONSTANTS_DEFAULT_SUBJECT).toString();
 
             // with attributes
             builder.withId(id)
@@ -72,7 +74,7 @@ public class HttpRequestProtocolResolver {
                         || StringUtils.equals(HttpProtocolConstant.CONSTANTS_KEY_SUBJECT, extension.getKey())) {
                     continue;
                 }
-                String lowerExtensionKey = extension.getKey().toLowerCase();
+                String lowerExtensionKey = extension.getKey().toLowerCase(Locale.getDefault());
                 builder.withExtension(lowerExtensionKey, sysHeaderMap.get(extension.getKey()).toString());
             }
 
@@ -90,10 +92,9 @@ public class HttpRequestProtocolResolver {
             data.put(HttpProtocolConstant.CONSTANTS_KEY_PATH, requestURI);
             data.put(HttpProtocolConstant.CONSTANTS_KEY_METHOD, httpEventWrapper.getHttpMethod());
             // with data
-            builder = builder.withData(JsonUtils.serialize(data).getBytes(StandardCharsets.UTF_8));
-            return builder.build();
+            return builder.withData(JsonUtils.serialize(data).getBytes(StandardCharsets.UTF_8)).build();
         } catch (Exception e) {
-            throw new ProtocolHandleException(e.getMessage(), e.getCause());
+            throw new ProtocolHandleException(e.getMessage(), e);
         }
     }
 }


### PR DESCRIPTION

Fixes #2629 .

### Motivation
pmd warn:
1.PreserveStackTrace .
2.UseLocaleWitchCaseConversions.

### Modifications

1.throw new Exception with the cause exception.
2.add default locale.


### Documentation

- Does this pull request introduce a new feature? ( no)
- If yes, how is the feature documented? (not documented)
