### PR TITLE
[ISSUE #2643] Class defines a computed serialVersionUID that doesn't equate to the calculated value [EventMeshException]

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/exception/EventMeshException.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/exception/EventMeshException.java
@@ -18,7 +18,7 @@
 package org.apache.eventmesh.common.exception;
 
 public class EventMeshException extends RuntimeException {
-    public static final long serialVersionUID = 5774485660304045938L;
+    public static final long serialVersionUID = 5648256502005456586L;
 
     public EventMeshException(String message) {
         super(message);


### PR DESCRIPTION
Fixes #2643 .

### Motivation

Class defines a computed serialVersionUID that doesn't equate to the calculated value [EventMeshException]

### Modifications

recompute the serialVersionUID using IDE.



### Documentation

- Does this pull request introduce a new feature? ( no)
- If yes, how is the feature documented? (not documented)
