### PR TITLE
[ISSUE #2661] Method uses immediate execution of a block of code that is often not used [AbstractEventProcessor]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/inf/AbstractEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/inf/AbstractEventProcessor.java
@@ -135,9 +135,7 @@ public class AbstractEventProcessor {
             Map<String, ConsumerGroupTopicMetadata> consumerGroupTopicMetadataMap =
                     Optional.ofNullable(consumerGroupMetadata)
                             .map(ConsumerGroupMetadata::getConsumerGroupTopicMetadataMap)
-                            .orElseGet(() -> {
-                                return Maps.newConcurrentMap();
-                            });
+                            .orElseGet(Maps::newConcurrentMap);
 
             for (SubscriptionItem subscriptionItem : subscriptionList) {
                 if (consumerGroupTopicMetadataMap.containsKey(subscriptionItem.getTopic())) {


### PR DESCRIPTION

Fixes #2661 .

### Motivation

Method uses immediate execution of a block of code that is often not used [AbstractEventProcessor]

### Modifications

refactor eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/inf/AbstractEventProcessor.java
use Optional.orElseGet()


### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? ( not documented)
