### PR TITLE
[ISSUE #2677] Method appears to call the same method on the same object redundantly [UnSubscribeProcessor]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/UnSubscribeProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/UnSubscribeProcessor.java
@@ -68,10 +68,11 @@ public class UnSubscribeProcessor implements HttpRequestProcessor {
     public void processRequest(ChannelHandlerContext ctx, AsyncContext<HttpCommand> asyncContext)
             throws Exception {
         HttpCommand responseEventMeshCommand;
+        String localAddress = IPUtils.getLocalAddress();
         httpLogger.info("cmd={}|{}|client2eventMesh|from={}|to={}",
                 RequestCode.get(Integer.valueOf(asyncContext.getRequest().getRequestCode())),
                 EventMeshConstants.PROTOCOL_HTTP,
-                RemotingHelper.parseChannelRemoteAddr(ctx.channel()), IPUtils.getLocalAddress());
+                RemotingHelper.parseChannelRemoteAddr(ctx.channel()), localAddress);
         UnSubscribeRequestHeader unSubscribeRequestHeader =
                 (UnSubscribeRequestHeader) asyncContext.getRequest().getHeader();
         UnSubscribeRequestBody unSubscribeRequestBody =
@@ -81,8 +82,7 @@ public class UnSubscribeProcessor implements HttpRequestProcessor {
                 UnSubscribeResponseHeader
                         .buildHeader(Integer.valueOf(asyncContext.getRequest().getRequestCode()),
                                 eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshCluster(),
-                                IPUtils.getLocalAddress(),
-                                eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshEnv(),
+                                localAddress, eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshEnv(),
                                 eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshIDC());
 
         //validate header


### PR DESCRIPTION
Fixes #2677 

### Motivation

Original code call then same method redundantly, this pr is about to fix it. 



### Modifications

refactor eventmesh-eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/UnSubscribeProcessor.java; use temporary variable to avoid redundantly calling same method.



### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
