### PR TITLE
[ISSUE #2695] AbstractEventProcessor can be defined as an abstract class and then implement AsyncHttpProcessor to make the structure clearer

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalSubscribeEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalSubscribeEventProcessor.java
@@ -60,7 +60,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 
 
 @EventMeshTrace(isEnable = false)
-public class LocalSubscribeEventProcessor extends AbstractEventProcessor implements AsyncHttpProcessor {
+public class LocalSubscribeEventProcessor extends AbstractEventProcessor {
 
     public Logger httpLogger = LoggerFactory.getLogger("http");
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalUnSubscribeEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalUnSubscribeEventProcessor.java
@@ -57,7 +57,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Maps;
 
 @EventMeshTrace(isEnable = false)
-public class LocalUnSubscribeEventProcessor extends AbstractEventProcessor implements AsyncHttpProcessor {
+public class LocalUnSubscribeEventProcessor extends AbstractEventProcessor {
 
     public Logger httpLogger = LoggerFactory.getLogger(EventMeshConstants.PROTOCOL_HTTP);
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/RemoteSubscribeEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/RemoteSubscribeEventProcessor.java
@@ -63,7 +63,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 
 @EventMeshTrace(isEnable = false)
-public class RemoteSubscribeEventProcessor extends AbstractEventProcessor implements AsyncHttpProcessor {
+public class RemoteSubscribeEventProcessor extends AbstractEventProcessor {
 
     public Logger httpLogger = LoggerFactory.getLogger(EventMeshConstants.PROTOCOL_HTTP);
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/RemoteUnSubscribeEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/RemoteUnSubscribeEventProcessor.java
@@ -63,7 +63,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 
 @EventMeshTrace(isEnable = false)
-public class RemoteUnSubscribeEventProcessor extends AbstractEventProcessor implements AsyncHttpProcessor {
+public class RemoteUnSubscribeEventProcessor extends AbstractEventProcessor {
 
     public Logger httpLogger = LoggerFactory.getLogger(EventMeshConstants.PROTOCOL_HTTP);
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/inf/AbstractEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/inf/AbstractEventProcessor.java
@@ -28,6 +28,7 @@ import org.apache.eventmesh.runtime.core.consumergroup.ConsumerGroupConf;
 import org.apache.eventmesh.runtime.core.consumergroup.ConsumerGroupMetadata;
 import org.apache.eventmesh.runtime.core.consumergroup.ConsumerGroupTopicConf;
 import org.apache.eventmesh.runtime.core.consumergroup.ConsumerGroupTopicMetadata;
+import org.apache.eventmesh.runtime.core.protocol.http.processor.AsyncHttpProcessor;
 import org.apache.eventmesh.runtime.registry.Registry;
 
 import org.apache.commons.lang3.StringUtils;
@@ -45,7 +46,7 @@ import com.google.common.collect.Maps;
 /**
  * EventProcessor
  */
-public class AbstractEventProcessor {
+public abstract class AbstractEventProcessor implements AsyncHttpProcessor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger("AbstractEventProcessor");
 


### PR DESCRIPTION
 Fixes https://github.com/apache/incubator-eventmesh/issues/2695
### Motivation

*Explain the content here.*
*Explain why you want to make the changes and what problem you're trying to solve.*



### Modifications

*Describe the modifications you've done.*



### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
