### PR TITLE
[ISSUE #2675] [Enhancement] Method appears to call the same method on the same object redundantly [SubscribeProcessor]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SubscribeProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SubscribeProcessor.java
@@ -75,12 +75,12 @@ public class SubscribeProcessor implements HttpRequestProcessor {
         HttpCommand responseEventMeshCommand;
         final HttpCommand request = asyncContext.getRequest();
         final Integer requestCode = Integer.valueOf(asyncContext.getRequest().getRequestCode());
+        final String localAddress = IPUtils.getLocalAddress();
 
         httpLogger.info("cmd={}|{}|client2eventMesh|from={}|to={}",
             RequestCode.get(requestCode),
             EventMeshConstants.PROTOCOL_HTTP,
-            RemotingHelper.parseChannelRemoteAddr(ctx.channel()), IPUtils.getLocalAddress()
-        );
+            RemotingHelper.parseChannelRemoteAddr(ctx.channel()), localAddress);
         SubscribeRequestHeader subscribeRequestHeader = (SubscribeRequestHeader) request.getHeader();
         SubscribeRequestBody subscribeRequestBody = (SubscribeRequestBody) request.getBody();
 
@@ -88,7 +88,7 @@ public class SubscribeProcessor implements HttpRequestProcessor {
             SubscribeResponseHeader
                 .buildHeader(requestCode,
                         eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshCluster(),
-                    IPUtils.getLocalAddress(),
+                        localAddress,
                         eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshEnv(),
                         eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshIDC());
 


### PR DESCRIPTION
Fixes #2675.

### Motivation

* Redundant function call in `eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SubscribeProcessor.java` lines  `82` and `91`.

### Modifications

* Method call combined with a local variable.


### Documentation

- Does this pull request introduces a new feature?  no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
