### PR TITLE
[ISSUE #2722] Method run() uses integer based for loops to iterate over a List

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/AbstractTask.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/AbstractTask.java
@@ -34,7 +34,7 @@ public abstract class AbstractTask implements Runnable {
     protected long startTime;
     protected EventMeshTCPServer eventMeshTCPServer;
 
-    public AbstractTask(Package pkg, ChannelHandlerContext ctx, long startTime, EventMeshTCPServer eventMeshTCPServer) {
+    public AbstractTask(final Package pkg, final ChannelHandlerContext ctx, long startTime, final EventMeshTCPServer eventMeshTCPServer) {
         this.eventMeshTCPServer = eventMeshTCPServer;
         this.pkg = pkg;
         this.ctx = ctx;


### PR DESCRIPTION

Fixes #2722 .

### Motivation

Method run() uses integer based for loops to iterate over a List


### Modifications

refactor
eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/task/SubscribeTask.java, repalce for with foreach.


### Documentation

- Does this pull request introduce a new feature? ( no)
- If yes, how is the feature documented? (not documented)
