### PR TITLE
[ISSUE #2710] Method stores return result in local before immediately returning it [RemotingHelper] 

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/RemotingHelper.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/RemotingHelper.java
@@ -24,21 +24,19 @@ import org.apache.commons.lang3.ArrayUtils;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
-
 import io.netty.channel.Channel;
 
 
-public class RemotingHelper {
+public abstract class RemotingHelper {
 
     public static String exceptionSimpleDesc(final Throwable e) {
-        StringBuilder sb = new StringBuilder();
+        final StringBuilder sb = new StringBuilder();
         if (e != null) {
             sb.append(e);
 
-            StackTraceElement[] stackTrace = e.getStackTrace();
+            final StackTraceElement[] stackTrace = e.getStackTrace();
             if (ArrayUtils.isNotEmpty(stackTrace)) {
-                StackTraceElement elment = stackTrace[0];
-                sb.append(", ").append(elment);
+                sb.append(", ").append(stackTrace[0]);
             }
         }
 
@@ -46,22 +44,21 @@ public class RemotingHelper {
     }
 
     public static SocketAddress string2SocketAddress(final String addr) {
-        int split = addr.lastIndexOf(":");
-        String host = addr.substring(0, split);
-        String port = addr.substring(split + 1);
-        InetSocketAddress isa = new InetSocketAddress(host, Integer.parseInt(port));
-        return isa;
+        final int split = addr.lastIndexOf(':');
+        final String host = addr.substring(0, split);
+        final String port = addr.substring(split + 1);
+        return new InetSocketAddress(host, Integer.parseInt(port));
     }
 
     public static String parseChannelRemoteAddr(final Channel channel) {
         if (null == channel) {
             return "";
         }
-        SocketAddress remote = channel.remoteAddress();
-        final String addr = remote != null ? remote.toString() : "";
+
+        final String addr = channel.remoteAddress() != null ? channel.remoteAddress().toString() : "";
 
         if (addr.length() > 0) {
-            int index = addr.lastIndexOf("/");
+            final int index = addr.lastIndexOf('/');
             if (index >= 0) {
                 return addr.substring(index + 1);
             }
@@ -72,11 +69,8 @@ public class RemotingHelper {
         return "";
     }
 
-    public static String parseSocketAddressAddr(InetSocketAddress socketAddress) {
-        if (socketAddress != null) {
-            return socketAddress.getAddress().getHostAddress() + ":" + socketAddress.getPort();
-        }
-        return "";
+    public static String parseSocketAddressAddr(final InetSocketAddress socketAddress) {
+        return socketAddress != null ? socketAddress.getAddress().getHostAddress() + ":" + socketAddress.getPort() : "";
     }
 
 }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/RemotingHelperTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/RemotingHelperTest.java
@@ -37,8 +37,9 @@ public class RemotingHelperTest {
     @Test
     public void testString2SocketAddress() {
         String addr = "10.1.1.1:11002";
-        SocketAddress address = RemotingHelper.string2SocketAddress(addr);
+        InetSocketAddress address = (InetSocketAddress) RemotingHelper.string2SocketAddress(addr);
         Assert.assertNotNull(address);
+        Assert.assertEquals("10.1.1.1:11002", address.getHostString() + ":" + address.getPort());
     }
 
     @Test


### PR DESCRIPTION


Fixes #2710 .

### Motivation

Method stores return result in local before immediately returning it [RemotingHelper] 

### Modifications

refacotr 
eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/RemotingHelper.java,
Returns the value assigned to the local variable directly, redefine as abstract class.


### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
- If a feature is not applicable for documentation, explain why?
