### PR TITLE
[ISSUE #2757] The init method of EventMeshGrpcProducer can be removed, and then it would be better to put the initialization behavior in the constructor

### DIFF
--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/pub/cloudevents/CloudEventsBatchPublishInstance.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/pub/cloudevents/CloudEventsBatchPublishInstance.java
@@ -56,9 +56,7 @@ public class CloudEventsBatchPublishInstance {
                 .sys("1234").build();
 
         try (EventMeshGrpcProducer eventMeshGrpcProducer = new EventMeshGrpcProducer(eventMeshClientConfig)) {
-
-            eventMeshGrpcProducer.init();
-
+            
             Map<String, String> content = new HashMap<>();
             content.put("content", "testRequestReplyMessage");
 

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/pub/cloudevents/CloudEventsPublishInstance.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/pub/cloudevents/CloudEventsPublishInstance.java
@@ -57,9 +57,7 @@ public class CloudEventsPublishInstance {
                 .sys("1234").build();
 
         try (EventMeshGrpcProducer eventMeshGrpcProducer = new EventMeshGrpcProducer(eventMeshClientConfig)) {
-
-            eventMeshGrpcProducer.init();
-
+            
             Map<String, String> content = new HashMap<>();
             content.put("content", "testAsyncMessage");
 

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/pub/cloudevents/CloudEventsRequestInstance.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/pub/cloudevents/CloudEventsRequestInstance.java
@@ -57,9 +57,7 @@ public class CloudEventsRequestInstance {
                 .sys("1234").build();
 
         try (EventMeshGrpcProducer eventMeshGrpcProducer = new EventMeshGrpcProducer(eventMeshClientConfig)) {
-
-            eventMeshGrpcProducer.init();
-
+            
             Map<String, String> content = new HashMap<>();
             content.put("content", "testRequestReplyMessage");
 

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/pub/eventmeshmessage/AsyncPublishBroadcast.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/pub/eventmeshmessage/AsyncPublishBroadcast.java
@@ -52,9 +52,7 @@ public class AsyncPublishBroadcast {
                 .sys("1234").build();
 
         try (EventMeshGrpcProducer eventMeshGrpcProducer = new EventMeshGrpcProducer(eventMeshClientConfig)) {
-
-            eventMeshGrpcProducer.init();
-
+            
             Map<String, String> content = new HashMap<>();
             content.put("content", "testAsyncMessage");
 

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/pub/eventmeshmessage/AsyncPublishInstance.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/pub/eventmeshmessage/AsyncPublishInstance.java
@@ -52,9 +52,7 @@ public class AsyncPublishInstance {
                 .sys("1234").build();
 
         try (EventMeshGrpcProducer eventMeshGrpcProducer = new EventMeshGrpcProducer(eventMeshClientConfig)) {
-
-            eventMeshGrpcProducer.init();
-
+            
             Map<String, String> content = new HashMap<>();
             content.put("content", "testAsyncMessage");
 

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/pub/eventmeshmessage/BatchPublishInstance.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/pub/eventmeshmessage/BatchPublishInstance.java
@@ -51,9 +51,7 @@ public class BatchPublishInstance {
                 .sys("1234").build();
 
         try (EventMeshGrpcProducer eventMeshGrpcProducer = new EventMeshGrpcProducer(eventMeshClientConfig)) {
-
-            eventMeshGrpcProducer.init();
-
+            
             Map<String, String> content = new HashMap<>();
             content.put("content", "testRequestReplyMessage");
 

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/pub/eventmeshmessage/RequestReplyInstance.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/pub/eventmeshmessage/RequestReplyInstance.java
@@ -53,9 +53,7 @@ public class RequestReplyInstance {
                 .sys("1234").build();
 
         try (EventMeshGrpcProducer eventMeshGrpcProducer = new EventMeshGrpcProducer(eventMeshClientConfig)) {
-
-            eventMeshGrpcProducer.init();
-
+            
             Map<String, String> content = new HashMap<>();
             content.put("content", "testRequestReplyMessage");
 

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/pub/eventmeshmessage/WorkflowAsyncPublishInstance.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/pub/eventmeshmessage/WorkflowAsyncPublishInstance.java
@@ -60,7 +60,6 @@ public class WorkflowAsyncPublishInstance {
                 .sys("DEFAULT").build();
 
         try (EventMeshGrpcProducer eventMeshGrpcProducer = new EventMeshGrpcProducer(eventMeshClientConfig)) {
-            eventMeshGrpcProducer.init();
 
             NacosSelector nacosSelector = new NacosSelector();
             nacosSelector.init();

--- a/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/grpc/producer/EventMeshGrpcProducer.java
+++ b/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/grpc/producer/EventMeshGrpcProducer.java
@@ -45,7 +45,7 @@ public class EventMeshGrpcProducer implements AutoCloseable {
 
     private final EventMeshGrpcClientConfig clientConfig;
 
-    private ManagedChannel channel;
+    private final ManagedChannel channel;
 
     PublisherServiceBlockingStub publisherClient;
 
@@ -53,11 +53,8 @@ public class EventMeshGrpcProducer implements AutoCloseable {
 
     public EventMeshGrpcProducer(EventMeshGrpcClientConfig clientConfig) {
         this.clientConfig = clientConfig;
-    }
-
-    public void init() {
         channel = ManagedChannelBuilder.forAddress(clientConfig.getServerAddr(), clientConfig.getServerPort())
-                .usePlaintext().build();
+            .usePlaintext().build();
         publisherClient = PublisherServiceGrpc.newBlockingStub(channel);
 
         cloudEventProducer = new CloudEventProducer(clientConfig, publisherClient);
@@ -81,7 +78,7 @@ public class EventMeshGrpcProducer implements AutoCloseable {
     public <T> Response publish(List<T> messageList) {
         logger.info("BatchPublish message " + messageList.toString());
 
-        if (messageList.size() == 0) {
+        if (messageList.isEmpty()) {
             return null;
         }
         if (messageList.get(0) instanceof CloudEvent) {


### PR DESCRIPTION
Fixes #2757 #2719 

### Motivation

*Explain the content here.*
*Explain why you want to make the changes and what problem you're trying to solve.*



### Modifications

*Describe the modifications you've done.*



### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
