### PR TITLE
[ISSUE #2704] Method handle(HttpExchange) manually handles closing an auto-closeable resource [RejectAllClientHandler] 

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/RejectAllClientHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/RejectAllClientHandler.java
@@ -42,11 +42,12 @@ import com.sun.net.httpserver.HttpExchange;
 @EventHttpHandler(path = "/clientManage/rejectAllClient")
 public class RejectAllClientHandler extends AbstractHttpHandler {
 
-    private static final Logger logger = LoggerFactory.getLogger(RejectAllClientHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RejectAllClientHandler.class);
 
-    private final EventMeshTCPServer eventMeshTCPServer;
+    private final transient EventMeshTCPServer eventMeshTCPServer;
 
-    public RejectAllClientHandler(EventMeshTCPServer eventMeshTCPServer, HttpHandlerManager httpHandlerManager) {
+    public RejectAllClientHandler(final EventMeshTCPServer eventMeshTCPServer,
+                                  final HttpHandlerManager httpHandlerManager) {
         super(httpHandlerManager);
         this.eventMeshTCPServer = eventMeshTCPServer;
     }
@@ -58,18 +59,18 @@ public class RejectAllClientHandler extends AbstractHttpHandler {
      * @throws IOException
      */
     @Override
-    public void handle(HttpExchange httpExchange) throws IOException {
-        String result = "";
-        OutputStream out = httpExchange.getResponseBody();
-        try {
-            ClientSessionGroupMapping clientSessionGroupMapping = eventMeshTCPServer.getClientSessionGroupMapping();
-            ConcurrentHashMap<InetSocketAddress, Session> sessionMap = clientSessionGroupMapping.getSessionMap();
+    public void handle(final HttpExchange httpExchange) throws IOException {
+        try (OutputStream out = httpExchange.getResponseBody()) {
+            final ClientSessionGroupMapping clientSessionGroupMapping = eventMeshTCPServer.getClientSessionGroupMapping();
+            final ConcurrentHashMap<InetSocketAddress, Session> sessionMap = clientSessionGroupMapping.getSessionMap();
             final List<InetSocketAddress> successRemoteAddrs = new ArrayList<>();
             try {
-                logger.info("rejectAllClient in admin====================");
+                if (LOGGER.isInfoEnabled()) {
+                    LOGGER.info("rejectAllClient in admin====================");
+                }
                 if (!sessionMap.isEmpty()) {
-                    for (Map.Entry<InetSocketAddress, Session> entry : sessionMap.entrySet()) {
-                        InetSocketAddress addr = EventMeshTcp2Client.serverGoodby2Client(
+                    for (final Map.Entry<InetSocketAddress, Session> entry : sessionMap.entrySet()) {
+                        final InetSocketAddress addr = EventMeshTcp2Client.serverGoodby2Client(
                                 eventMeshTCPServer, entry.getValue(), clientSessionGroupMapping);
                         if (addr != null) {
                             successRemoteAddrs.add(addr);
@@ -77,27 +78,18 @@ public class RejectAllClientHandler extends AbstractHttpHandler {
                     }
                 }
             } catch (Exception e) {
-                logger.error("clientManage|rejectAllClient|fail", e);
-                result = String.format("rejectAllClient fail! sessionMap size {%d}, had reject {%s}, errorMsg : %s",
-                        sessionMap.size(), NetUtils.addressToString(successRemoteAddrs), e.getMessage());
+                LOGGER.error("clientManage rejectAllClient fail", e);
                 NetUtils.sendSuccessResponseHeaders(httpExchange);
-                out.write(result.getBytes(Constants.DEFAULT_CHARSET));
+                out.write(String.format("rejectAllClient fail! sessionMap size {%d}, had reject {%s}, errorMsg : %s",
+                                sessionMap.size(), NetUtils.addressToString(successRemoteAddrs), e.getMessage())
+                        .getBytes(Constants.DEFAULT_CHARSET));
                 return;
             }
-            result = String.format("rejectAllClient success! sessionMap size {%d}, had reject {%s}", sessionMap.size(),
-                    NetUtils.addressToString(successRemoteAddrs));
             NetUtils.sendSuccessResponseHeaders(httpExchange);
-            out.write(result.getBytes(Constants.DEFAULT_CHARSET));
+            out.write(String.format("rejectAllClient success! sessionMap size {%d}, had reject {%s}", sessionMap.size(),
+                    NetUtils.addressToString(successRemoteAddrs)).getBytes(Constants.DEFAULT_CHARSET));
         } catch (Exception e) {
-            logger.error("rejectAllClient fail...", e);
-        } finally {
-            if (out != null) {
-                try {
-                    out.close();
-                } catch (IOException e) {
-                    logger.warn("out close failed...", e);
-                }
-            }
+            LOGGER.error("rejectAllClient fail.", e);
         }
     }
 }


### PR DESCRIPTION


Fixes #2704 .

### Motivation

Method handle(HttpExchange) manually handles closing an auto-closeable resource [RejectAllClientHandler] 


### Modifications

refactor eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/RejectAllClientHandler.java,
change to use try-with-resources to manage resources.


### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
