### PR TITLE
[ISSUE #2706] Method handle(HttpExchange) manually handles closing an auto-closeable resource [SSLContextFactory]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/AbstractHTTPServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/AbstractHTTPServer.java
@@ -169,12 +169,13 @@ public abstract class AbstractHTTPServer extends AbstractRemotingServer {
     public void start() throws Exception {
         Runnable r = () -> {
             ServerBootstrap b = new ServerBootstrap();
-            SSLContext sslContext = useTLS ? SSLContextFactory.getSslContext(eventMeshHttpConfiguration) : null;
-            b.group(this.getBossGroup(), this.getWorkerGroup())
-                    .channel(NioServerSocketChannel.class)
-                    .childHandler(new HttpsServerInitializer(sslContext))
-                    .childOption(ChannelOption.SO_KEEPALIVE, Boolean.TRUE);
             try {
+                SSLContext sslContext = useTLS ? SSLContextFactory.getSslContext(eventMeshHttpConfiguration) : null;
+                b.group(this.getBossGroup(), this.getWorkerGroup())
+                        .channel(NioServerSocketChannel.class)
+                        .childHandler(new HttpsServerInitializer(sslContext))
+                        .childOption(ChannelOption.SO_KEEPALIVE, Boolean.TRUE);
+
                 httpServerLogger.info("HTTPServer[port={}] started......", this.getPort());
                 ChannelFuture future = b.bind(this.getPort()).sync();
                 future.channel().closeFuture().sync();

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/SSLContextFactory.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/SSLContextFactory.java
@@ -30,7 +30,12 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.security.KeyManagementException;
 import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -39,49 +44,34 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SSLContextFactory {
-    private static Logger httpLogger = LoggerFactory.getLogger("http");
-
     private static String protocol = "TLSv1.1";
 
     private static String fileName;
 
-    private static String pass;
+    private static String password;
 
-
-    public static SSLContext getSslContext(EventMeshHTTPConfiguration eventMeshHttpConfiguration) {
+    public static SSLContext getSslContext(final EventMeshHTTPConfiguration eventMeshHttpConfiguration)
+            throws NoSuchAlgorithmException, KeyStoreException, CertificateException, IOException,
+            UnrecoverableKeyException, KeyManagementException {
         SSLContext sslContext;
-        InputStream inputStream = null;
-        try {
-            protocol = eventMeshHttpConfiguration.eventMeshServerSSLProtocol;
 
-            fileName = eventMeshHttpConfiguration.eventMeshServerSSLCer;
-
-            char[] filePass = null;
-            pass = eventMeshHttpConfiguration.eventMeshServerSSLPass;
-            if (StringUtils.isNotBlank(pass)) {
-                filePass = pass.toCharArray();
-            }
-            sslContext = SSLContext.getInstance(protocol);
-            KeyStore keyStore = KeyStore.getInstance("JKS");
-            inputStream = Files.newInputStream(Paths.get(EventMeshConstants.EVENTMESH_CONF_HOME
+        try (InputStream inputStream = Files.newInputStream(Paths.get(EventMeshConstants.EVENTMESH_CONF_HOME
                 + File.separator
-                + fileName), StandardOpenOption.READ);
+                + fileName), StandardOpenOption.READ)) {
+            protocol = eventMeshHttpConfiguration.eventMeshServerSSLProtocol;
+            fileName = eventMeshHttpConfiguration.eventMeshServerSSLCer;
+            password = eventMeshHttpConfiguration.eventMeshServerSSLPass;
+
+            char[] filePass = StringUtils.isNotBlank(password) ? password.toCharArray() : new char[0];
+            final KeyStore keyStore = KeyStore.getInstance("JKS");
             keyStore.load(inputStream, filePass);
-            KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            final KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
             kmf.init(keyStore, filePass);
+
+            sslContext = SSLContext.getInstance(protocol);
             sslContext.init(kmf.getKeyManagers(), null, null);
-        } catch (Exception e) {
-            httpLogger.warn("sslContext init failed", e);
-            sslContext = null;
-        } finally {
-            if (inputStream != null) {
-                try {
-                    inputStream.close();
-                } catch (IOException e) {
-                    httpLogger.warn("IOException found", e);
-                }
-            }
         }
+
         return sslContext;
     }
 }


### PR DESCRIPTION

Fixes #2706 .

### Motivation

Method handle(HttpExchange) manually handles closing an auto-closeable resource [SSLContextFactory]


### Modifications

refactor eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/SSLContextFactory.java,
change to use try-with-resources to manage resources.



### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
