### PR TITLE
[ISSUE #2709] Method stores return result in local before immediately returning it [FreePriorityDispatchStrategy] 

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/group/dispatch/FreePriorityDispatchStrategy.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/group/dispatch/FreePriorityDispatchStrategy.java
@@ -35,7 +35,7 @@ public class FreePriorityDispatchStrategy implements DownstreamDispatchStrategy 
     private static final Logger LOGGER = LoggerFactory.getLogger(FreePriorityDispatchStrategy.class);
 
     @Override
-    public Session select(final String group,final  String topic,final  Set<Session> groupConsumerSessions) {
+    public Session select(final String group, final String topic, final Set<Session> groupConsumerSessions) {
         if (CollectionUtils.isEmpty(groupConsumerSessions)
                 || StringUtils.isBlank(topic)
                 || StringUtils.isBlank(group)) {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/group/dispatch/FreePriorityDispatchStrategy.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/group/dispatch/FreePriorityDispatchStrategy.java
@@ -32,43 +32,50 @@ import org.slf4j.LoggerFactory;
 
 public class FreePriorityDispatchStrategy implements DownstreamDispatchStrategy {
 
-    private static final Logger logger = LoggerFactory.getLogger(FreePriorityDispatchStrategy.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FreePriorityDispatchStrategy.class);
 
     @Override
-    public Session select(String group, String topic, Set<Session> groupConsumerSessions) {
+    public Session select(final String group,final  String topic,final  Set<Session> groupConsumerSessions) {
         if (CollectionUtils.isEmpty(groupConsumerSessions)
                 || StringUtils.isBlank(topic)
                 || StringUtils.isBlank(group)) {
             return null;
         }
 
-        List<Session> filtered = new ArrayList<Session>();
-        List<Session> isolatedSessions = new ArrayList<>();
-        for (Session session : groupConsumerSessions) {
+        final List<Session> filtered = new ArrayList<>();
+        final List<Session> isolatedSessions = new ArrayList<>();
+        for (final Session session : groupConsumerSessions) {
             if (!session.isAvailable(topic)) {
                 continue;
             }
+
             if (session.isIsolated()) {
                 isolatedSessions.add(session);
-                logger.info("session is not available because session is isolated,isolateTime:{},client:{}",
-                        session.getIsolateTime(), session.getClient());
+                if (LOGGER.isInfoEnabled()) {
+                    LOGGER.info("session is not available because session is isolated,isolateTime:{},client:{}",
+                            session.getIsolateTime(), session.getClient());
+                }
                 continue;
             }
+
             filtered.add(session);
         }
 
         if (CollectionUtils.isEmpty(filtered)) {
             if (CollectionUtils.isEmpty(isolatedSessions)) {
-                logger.warn("all sessions can't downstream msg");
+                if (LOGGER.isWarnEnabled()) {
+                    LOGGER.warn("all sessions can't downstream msg");
+                }
                 return null;
             } else {
-                logger.warn("all sessions are isolated,group:{},topic:{}", group, topic);
+                if (LOGGER.isWarnEnabled()) {
+                    LOGGER.warn("all sessions are isolated,group:{},topic:{}", group, topic);
+                }
                 filtered.addAll(isolatedSessions);
             }
         }
 
         Collections.shuffle(filtered);
-        Session session = filtered.get(0);
-        return session;
+        return filtered.get(0);
     }
 }


### PR DESCRIPTION

Fixes #2709 .

### Motivation

Method stores return result in local before immediately returning it [FreePriorityDispatchStrategy] 


### Modifications

refactor eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/group/dispatch/FreePriorityDispatchStrategy.java.

### Documentation

- Does this pull request introduce a new feature? ( no)
- If yes, how is the feature documented? ( not documented)
