### PR TITLE
[ISSUE #2729] Method check a map with containsKey(), before using get() [UnSubscribeProcessor]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/HttpClientGroupMapping.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/HttpClientGroupMapping.java
@@ -350,23 +350,23 @@ public class HttpClientGroupMapping {
                                       final List<SubscriptionItem> subscriptionItems, final String url) {
         for (SubscriptionItem item : subscriptionItems) {
             Client client = new Client();
-            client.env = subscribeRequestHeader.getEnv();
-            client.idc = subscribeRequestHeader.getIdc();
-            client.sys = subscribeRequestHeader.getSys();
-            client.ip = subscribeRequestHeader.getIp();
-            client.pid = subscribeRequestHeader.getPid();
-            client.consumerGroup = consumerGroup;
-            client.topic = item.getTopic();
-            client.url = url;
-            client.lastUpTime = new Date();
-            String groupTopicKey = client.consumerGroup + "@" + client.topic;
+            client.setEnv(subscribeRequestHeader.getEnv());
+            client.setIdc(subscribeRequestHeader.getIdc());
+            client.setSys(subscribeRequestHeader.getSys());
+            client.setIp(subscribeRequestHeader.getIp());
+            client.setPid(subscribeRequestHeader.getPid());
+            client.setConsumerGroup(consumerGroup);
+            client.setTopic(item.getTopic());
+            client.setUrl(url);
+            client.setLastUpTime(new Date());
+            String groupTopicKey = client.getConsumerGroup() + "@" + client.getTopic();
             if (localClientInfoMapping.containsKey(groupTopicKey)) {
                 List<Client> localClients = localClientInfoMapping.get(groupTopicKey);
                 boolean isContains = false;
                 for (Client localClient : localClients) {
-                    if (StringUtils.equals(localClient.url, client.url)) {
+                    if (StringUtils.equals(localClient.getUrl(), client.getUrl())) {
                         isContains = true;
-                        localClient.lastUpTime = client.lastUpTime;
+                        localClient.setLastUpTime(client.getLastUpTime());
                         break;
                     }
                 }
@@ -409,25 +409,25 @@ public class HttpClientGroupMapping {
                                         final List<String> topicList, String url) {
         for (String topic : topicList) {
             Client client = new Client();
-            client.env = unSubscribeRequestHeader.getEnv();
-            client.idc = unSubscribeRequestHeader.getIdc();
-            client.sys = unSubscribeRequestHeader.getSys();
-            client.ip = unSubscribeRequestHeader.getIp();
-            client.pid = unSubscribeRequestHeader.getPid();
-            client.consumerGroup = consumerGroup;
-            client.topic = topic;
-            client.url = url;
-            client.lastUpTime = new Date();
-            String groupTopicKey = client.consumerGroup + "@" + client.topic;
+            client.setEnv(unSubscribeRequestHeader.getEnv());
+            client.setIdc(unSubscribeRequestHeader.getIdc());
+            client.setSys(unSubscribeRequestHeader.getSys());
+            client.setIp(unSubscribeRequestHeader.getIp());
+            client.setPid(unSubscribeRequestHeader.getPid());
+            client.setConsumerGroup(consumerGroup);
+            client.setTopic(topic);
+            client.setUrl(url);
+            client.setLastUpTime(new Date());
+            String groupTopicKey = client.getConsumerGroup() + "@" + client.getTopic();
 
             if (localClientInfoMapping.containsKey(groupTopicKey)) {
                 List<Client> localClients =
                         localClientInfoMapping.get(groupTopicKey);
                 boolean isContains = false;
                 for (Client localClient : localClients) {
-                    if (StringUtils.equals(localClient.url, client.url)) {
+                    if (StringUtils.equals(localClient.getUrl(), client.getUrl())) {
                         isContains = true;
-                        localClient.lastUpTime = client.lastUpTime;
+                        localClient.setLastUpTime(client.getLastUpTime());
                         break;
                     }
                 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/HttpClientGroupMapping.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/HttpClientGroupMapping.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -45,25 +46,25 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class HttpClientGroupMapping {
+public final class HttpClientGroupMapping {
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpClientGroupMapping.class);
 
-    private final transient ConcurrentHashMap<String /**group*/, ConsumerGroupConf> localConsumerGroupMapping =
+    private final transient Map<String /**group*/, ConsumerGroupConf> localConsumerGroupMapping =
             new ConcurrentHashMap<>();
 
-    private final transient ConcurrentHashMap<String /**group@topic*/, List<Client>> localClientInfoMapping =
+    private final transient Map<String /**group@topic*/, List<Client>> localClientInfoMapping =
             new ConcurrentHashMap<>();
 
     private final transient Set<String> localTopicSet = new HashSet<String>(16);
 
-    private transient ReadWriteLock lock = new ReentrantReadWriteLock();
+    private static final transient ReadWriteLock READ_WRITE_LOCK = new ReentrantReadWriteLock();
 
     private HttpClientGroupMapping() {
 
     }
 
     private static class Singleton {
-        private static HttpClientGroupMapping INSTANCE = new HttpClientGroupMapping();
+        private static final HttpClientGroupMapping INSTANCE = new HttpClientGroupMapping();
     }
 
     public static HttpClientGroupMapping getInstance() {
@@ -74,40 +75,45 @@ public class HttpClientGroupMapping {
         return localTopicSet;
     }
 
-    public ConcurrentHashMap<String, List<Client>> getLocalClientInfoMapping() {
+    public Map<String, List<Client>> getLocalClientInfoMapping() {
         return localClientInfoMapping;
     }
 
-    public ConsumerGroupConf getConsumerGroupConfByGroup(String consumerGroup) {
+    public ConsumerGroupConf getConsumerGroupConfByGroup(final String consumerGroup) {
         return localConsumerGroupMapping.get(consumerGroup);
     }
 
-    public boolean addSubscription(String consumerGroup, String url, String clientIdc,
+    public boolean addSubscription(final String consumerGroup, final String url, final String clientIdc,
                                    final List<SubscriptionItem> subscriptionList) {
+        Objects.requireNonNull(url, "url can not be null");
+        Objects.requireNonNull(consumerGroup, "consumerGroup can not be null");
+        Objects.requireNonNull(clientIdc, "clientIdc can not be null");
+        Objects.requireNonNull(subscriptionList, "subscriptionList can not be null");
+
         boolean isChange = false;
         try {
-            lock.writeLock().lock();
-            for (SubscriptionItem subTopic : subscriptionList) {
-                boolean flag = addSubscriptionByTopic(consumerGroup, url, clientIdc, subTopic);
-                isChange = isChange || flag;
+            READ_WRITE_LOCK.writeLock().lock();
+            for (final SubscriptionItem subTopic : subscriptionList) {
+                isChange = isChange || addSubscriptionByTopic(consumerGroup, url, clientIdc, subTopic);
             }
         } finally {
-            lock.writeLock().unlock();
+            READ_WRITE_LOCK.writeLock().unlock();
         }
         return isChange;
     }
 
-    public boolean removeSubscription(String consumerGroup, String unSubscribeUrl, String clientIdc,
+    public boolean removeSubscription(final String consumerGroup, final String unSubscribeUrl, final String clientIdc,
                                       final List<String> unSubTopicList) {
+        Objects.requireNonNull(unSubTopicList, "unSubTopicList can not be null");
+
         boolean isChange = false;
         try {
-            lock.writeLock().lock();
-            for (String unSubTopic : unSubTopicList) {
-                boolean flag = removeSubscriptionByTopic(consumerGroup, unSubscribeUrl, clientIdc, unSubTopic);
-                isChange = isChange || flag;
+            READ_WRITE_LOCK.writeLock().lock();
+            for (final String unSubTopic : unSubTopicList) {
+                isChange = isChange || removeSubscriptionByTopic(consumerGroup, unSubscribeUrl, clientIdc, unSubTopic);
             }
         } finally {
-            lock.writeLock().unlock();
+            READ_WRITE_LOCK.writeLock().unlock();
         }
         return isChange;
     }
@@ -115,20 +121,20 @@ public class HttpClientGroupMapping {
     public List<ConsumerGroupTopicConf> querySubscription() {
 
         try {
-            lock.readLock().lock();
+            READ_WRITE_LOCK.readLock().lock();
 
-            if (localConsumerGroupMapping == null || localConsumerGroupMapping.size() <= 0) {
-                return null;
+            if (MapUtils.isEmpty(localConsumerGroupMapping)) {
+                return new ArrayList<>();
             }
 
-            List<ConsumerGroupTopicConf> consumerGroupTopicConfList = new ArrayList<ConsumerGroupTopicConf>();
+            final List<ConsumerGroupTopicConf> consumerGroupTopicConfList = new ArrayList<>();
 
-            for (ConsumerGroupConf consumerGroupConf : localConsumerGroupMapping.values()) {
+            for (final ConsumerGroupConf consumerGroupConf : localConsumerGroupMapping.values()) {
                 if (MapUtils.isEmpty(consumerGroupConf.getConsumerGroupTopicConf())) {
                     continue;
                 }
 
-                for (ConsumerGroupTopicConf consumerGroupTopicConf : consumerGroupConf.getConsumerGroupTopicConf().values()) {
+                for (final ConsumerGroupTopicConf consumerGroupTopicConf : consumerGroupConf.getConsumerGroupTopicConf().values()) {
                     consumerGroupTopicConfList.add(consumerGroupTopicConf);
                 }
             }
@@ -136,101 +142,118 @@ public class HttpClientGroupMapping {
             return consumerGroupTopicConfList;
 
         } finally {
-            lock.readLock().unlock();
+            READ_WRITE_LOCK.readLock().unlock();
         }
 
     }
 
     public Map<String, String> prepareMetaData() {
-        Map<String, String> metadata = new HashMap<>(1 << 4);
-        try {
-            lock.readLock().lock();
+        final Map<String, String> metadata = new HashMap<>(1 << 4);
 
-            for (Map.Entry<String, ConsumerGroupConf> consumerGroupMap : localConsumerGroupMapping.entrySet()) {
-                String consumerGroupKey = consumerGroupMap.getKey();
-                ConsumerGroupConf consumerGroupConf = consumerGroupMap.getValue();
-                ConsumerGroupMetadata consumerGroupMetadata = new ConsumerGroupMetadata();
+        try {
+            READ_WRITE_LOCK.readLock().lock();
+
+            for (final Map.Entry<String, ConsumerGroupConf> consumerGroupMap : localConsumerGroupMapping.entrySet()) {
+                final String consumerGroupKey = consumerGroupMap.getKey();
+                final ConsumerGroupConf consumerGroupConf = consumerGroupMap.getValue();
+                final ConsumerGroupMetadata consumerGroupMetadata = new ConsumerGroupMetadata();
+
                 consumerGroupMetadata.setConsumerGroup(consumerGroupKey);
-                Map<String, ConsumerGroupTopicMetadata> consumerGroupTopicMetadataMap = new HashMap<>(1 << 4);
-                for (Map.Entry<String, ConsumerGroupTopicConf> consumerGroupTopicConfEntry : consumerGroupConf.getConsumerGroupTopicConf()
-                        .entrySet()) {
-                    final String topic = consumerGroupTopicConfEntry.getKey();
-                    ConsumerGroupTopicConf consumerGroupTopicConf = consumerGroupTopicConfEntry.getValue();
-                    ConsumerGroupTopicMetadata consumerGroupTopicMetadata = new ConsumerGroupTopicMetadata();
+
+                final Map<String, ConsumerGroupTopicMetadata> consumerGroupTopicMetadataMap =
+                        new HashMap<>(1 << 4);
+                for (final Map.Entry<String, ConsumerGroupTopicConf> consumerGroupTopicConfEntry
+                        : consumerGroupConf.getConsumerGroupTopicConf().entrySet()) {
+                    final ConsumerGroupTopicConf consumerGroupTopicConf = consumerGroupTopicConfEntry.getValue();
+                    final ConsumerGroupTopicMetadata consumerGroupTopicMetadata = new ConsumerGroupTopicMetadata();
                     consumerGroupTopicMetadata.setConsumerGroup(consumerGroupTopicConf.getConsumerGroup());
                     consumerGroupTopicMetadata.setTopic(consumerGroupTopicConf.getTopic());
                     consumerGroupTopicMetadata.setUrls(consumerGroupTopicConf.getUrls());
-                    consumerGroupTopicMetadataMap.put(topic, consumerGroupTopicMetadata);
+                    consumerGroupTopicMetadataMap.put(consumerGroupTopicConfEntry.getKey(), consumerGroupTopicMetadata);
                 }
                 consumerGroupMetadata.setConsumerGroupTopicMetadataMap(consumerGroupTopicMetadataMap);
                 metadata.put(consumerGroupKey, JsonUtils.serialize(consumerGroupMetadata));
             }
         } finally {
-            lock.readLock().unlock();
+            READ_WRITE_LOCK.readLock().unlock();
         }
+
         metadata.put("topicSet", JsonUtils.serialize(localTopicSet));
         return metadata;
     }
 
-    public boolean addSubscriptionForRequestCode(SubscribeRequestHeader subscribeRequestHeader,
-                                                 String consumerGroup,
-                                                 String url,
+    public boolean addSubscriptionForRequestCode(final SubscribeRequestHeader subscribeRequestHeader,
+                                                 final String consumerGroup,
+                                                 final String url,
                                                  final List<SubscriptionItem> subscriptionList) {
+        Objects.requireNonNull(url, "url can not be null");
+        Objects.requireNonNull(consumerGroup, "consumerGroup can not be null");
+        Objects.requireNonNull(subscribeRequestHeader, "subscribeRequestHeader can not be null");
+        Objects.requireNonNull(subscriptionList, "subscriptionList can not be null");
+
         boolean isChange = false;
         try {
-            lock.writeLock().lock();
+            READ_WRITE_LOCK.writeLock().lock();
+
             registerClientForSub(subscribeRequestHeader, consumerGroup, subscriptionList, url);
-            for (SubscriptionItem subTopic : subscriptionList) {
+            for (final SubscriptionItem subTopic : subscriptionList) {
                 isChange = isChange
                         || addSubscriptionByTopic(consumerGroup, url, subscribeRequestHeader.getIdc(), subTopic);
             }
         } finally {
-            lock.writeLock().unlock();
+            READ_WRITE_LOCK.writeLock().unlock();
         }
         return isChange;
     }
 
-    private boolean addSubscriptionByTopic(String consumerGroup, String url, String clientIdc, SubscriptionItem subTopic) {
+    private boolean addSubscriptionByTopic(final String consumerGroup, final String url, final String clientIdc,
+                                           final SubscriptionItem subTopic) {
+        Objects.requireNonNull(url, "url can not be null");
+        Objects.requireNonNull(consumerGroup, "consumerGroup can not be null");
+        Objects.requireNonNull(clientIdc, "clientIdc can not be null");
+        Objects.requireNonNull(subTopic, "subTopic can not be null");
+
         boolean isChange = false;
+
         ConsumerGroupConf consumerGroupConf = localConsumerGroupMapping.get(consumerGroup);
         if (consumerGroupConf == null) {
             // new subscription
             consumerGroupConf = new ConsumerGroupConf(consumerGroup);
-            ConsumerGroupTopicConf consumeTopicConfig = new ConsumerGroupTopicConf();
+            final ConsumerGroupTopicConf consumeTopicConfig = new ConsumerGroupTopicConf();
             consumeTopicConfig.setConsumerGroup(consumerGroup);
             consumeTopicConfig.setTopic(subTopic.getTopic());
             consumeTopicConfig.setSubscriptionItem(subTopic);
             consumeTopicConfig.setUrls(new HashSet<>(Collections.singletonList(url)));
-            Map<String, List<String>> idcUrls = new HashMap<>();
-            List<String> urls = new ArrayList<String>();
+            final Map<String, List<String>> idcUrls = new HashMap<>();
+            final List<String> urls = new ArrayList<String>();
             urls.add(url);
             idcUrls.put(clientIdc, urls);
             consumeTopicConfig.setIdcUrls(idcUrls);
-            Map<String, ConsumerGroupTopicConf> map = new HashMap<>();
+            final Map<String, ConsumerGroupTopicConf> map = new HashMap<>();
             map.put(subTopic.getTopic(), consumeTopicConfig);
             consumerGroupConf.setConsumerGroupTopicConf(map);
             localConsumerGroupMapping.put(consumerGroup, consumerGroupConf);
             isChange = true;
         } else {
             // already subscribed
-            Map<String, ConsumerGroupTopicConf> map =
+            final Map<String, ConsumerGroupTopicConf> map =
                     consumerGroupConf.getConsumerGroupTopicConf();
             if (!map.containsKey(subTopic.getTopic())) {
                 //If there are multiple topics, append it
-                ConsumerGroupTopicConf newTopicConf = new ConsumerGroupTopicConf();
+                final ConsumerGroupTopicConf newTopicConf = new ConsumerGroupTopicConf();
                 newTopicConf.setConsumerGroup(consumerGroup);
                 newTopicConf.setTopic(subTopic.getTopic());
                 newTopicConf.setSubscriptionItem(subTopic);
                 newTopicConf.setUrls(new HashSet<>(Collections.singletonList(url)));
-                Map<String, List<String>> idcUrls = new HashMap<>();
-                List<String> urls = new ArrayList<String>();
+                final Map<String, List<String>> idcUrls = new HashMap<>();
+                final List<String> urls = new ArrayList<String>();
                 urls.add(url);
                 idcUrls.put(clientIdc, urls);
                 newTopicConf.setIdcUrls(idcUrls);
                 map.put(subTopic.getTopic(), newTopicConf);
                 isChange = true;
             } else {
-                ConsumerGroupTopicConf currentTopicConf = map.get(subTopic.getTopic());
+                final ConsumerGroupTopicConf currentTopicConf = map.get(subTopic.getTopic());
                 if (!currentTopicConf.getUrls().add(url)) {
                     isChange = true;
                     if (LOGGER.isInfoEnabled()) {
@@ -245,7 +268,7 @@ public class HttpClientGroupMapping {
                 }
 
                 if (!currentTopicConf.getIdcUrls().containsKey(clientIdc)) {
-                    List<String> urls = new ArrayList<String>();
+                    final List<String> urls = new ArrayList<String>();
                     urls.add(url);
                     currentTopicConf.getIdcUrls().put(clientIdc, urls);
                     isChange = true;
@@ -254,7 +277,7 @@ public class HttpClientGroupMapping {
                                 consumerGroup, url, subTopic.getTopic(), clientIdc);
                     }
                 } else {
-                    Set<String> tmpSet = new HashSet<>(currentTopicConf.getIdcUrls().get(clientIdc));
+                    final Set<String> tmpSet = new HashSet<>(currentTopicConf.getIdcUrls().get(clientIdc));
                     if (!tmpSet.contains(url)) {
                         currentTopicConf.getIdcUrls().get(clientIdc).add(url);
                         isChange = true;
@@ -274,10 +297,16 @@ public class HttpClientGroupMapping {
         return isChange;
     }
 
-    private boolean removeSubscriptionByTopic(String consumerGroup, String unSubscribeUrl, String clientIdc,
-                                              String unSubTopic) {
+    private boolean removeSubscriptionByTopic(final String consumerGroup, final String unSubscribeUrl,
+                                              final String clientIdc, final String unSubTopic) {
+        Objects.requireNonNull(unSubscribeUrl, "unSubscribeUrl can not be null");
+        Objects.requireNonNull(consumerGroup, "consumerGroup can not be null");
+        Objects.requireNonNull(clientIdc, "clientIdc can not be null");
+        Objects.requireNonNull(unSubTopic, "unSubTopic can not be null");
+
         boolean isChange = false;
-        ConsumerGroupConf consumerGroupConf = localConsumerGroupMapping.get(consumerGroup);
+
+        final ConsumerGroupConf consumerGroupConf = localConsumerGroupMapping.get(consumerGroup);
         if (consumerGroupConf == null) {
             if (LOGGER.isWarnEnabled()) {
                 LOGGER.warn("unsubscribe fail, the current mesh does not have group subscriptionInfo, group:{}, url:{}",
@@ -286,7 +315,7 @@ public class HttpClientGroupMapping {
             return false;
         }
 
-        ConsumerGroupTopicConf consumerGroupTopicConf = consumerGroupConf.getConsumerGroupTopicConf().get(unSubTopic);
+        final ConsumerGroupTopicConf consumerGroupTopicConf = consumerGroupConf.getConsumerGroupTopicConf().get(unSubTopic);
         if (consumerGroupTopicConf == null) {
             if (LOGGER.isWarnEnabled()) {
                 LOGGER.warn(
@@ -348,8 +377,13 @@ public class HttpClientGroupMapping {
 
     private void registerClientForSub(final SubscribeRequestHeader subscribeRequestHeader, final String consumerGroup,
                                       final List<SubscriptionItem> subscriptionItems, final String url) {
-        for (SubscriptionItem item : subscriptionItems) {
-            Client client = new Client();
+        Objects.requireNonNull(subscribeRequestHeader, "subscribeRequestHeader can not be null");
+        Objects.requireNonNull(consumerGroup, "consumerGroup can not be null");
+        Objects.requireNonNull(subscriptionItems, "subscriptionItems can not be null");
+        Objects.requireNonNull(url, "url can not be null");
+
+        for (final SubscriptionItem item : subscriptionItems) {
+            final Client client = new Client();
             client.setEnv(subscribeRequestHeader.getEnv());
             client.setIdc(subscribeRequestHeader.getIdc());
             client.setSys(subscribeRequestHeader.getSys());
@@ -359,11 +393,12 @@ public class HttpClientGroupMapping {
             client.setTopic(item.getTopic());
             client.setUrl(url);
             client.setLastUpTime(new Date());
-            String groupTopicKey = client.getConsumerGroup() + "@" + client.getTopic();
+            final String groupTopicKey = client.getConsumerGroup() + "@" + client.getTopic();
+
             if (localClientInfoMapping.containsKey(groupTopicKey)) {
-                List<Client> localClients = localClientInfoMapping.get(groupTopicKey);
+                final List<Client> localClients = localClientInfoMapping.get(groupTopicKey);
                 boolean isContains = false;
-                for (Client localClient : localClients) {
+                for (final Client localClient : localClients) {
                     if (StringUtils.equals(localClient.getUrl(), client.getUrl())) {
                         isContains = true;
                         localClient.setLastUpTime(client.getLastUpTime());
@@ -375,40 +410,51 @@ public class HttpClientGroupMapping {
                     localClients.add(client);
                 }
             } else {
-                List<Client> clients = new ArrayList<>();
+                final List<Client> clients = new ArrayList<>();
                 clients.add(client);
                 localClientInfoMapping.put(groupTopicKey, clients);
             }
         }
     }
 
-    public boolean removeSubscriptionForRequestCode(UnSubscribeRequestHeader unSubscribeRequestHeader,
-                                                    String consumerGroup,
-                                                    String unSubscribeUrl,
+    public boolean removeSubscriptionForRequestCode(final UnSubscribeRequestHeader unSubscribeRequestHeader,
+                                                    final String consumerGroup,
+                                                    final String unSubscribeUrl,
                                                     final List<String> unSubTopicList) {
+        Objects.requireNonNull(unSubTopicList, "unSubTopicList can not be null");
+        Objects.requireNonNull(unSubscribeRequestHeader, "unSubscribeRequestHeader can not be null");
+        Objects.requireNonNull(consumerGroup, "consumerGroup can not be null");
+        Objects.requireNonNull(unSubscribeUrl, "unSubscribeUrl can not be null");
+
         boolean isChange = false;
         try {
-            lock.writeLock().lock();
+            READ_WRITE_LOCK.writeLock().lock();
+
             registerClientForUnsub(unSubscribeRequestHeader, consumerGroup, unSubTopicList, unSubscribeUrl);
-            for (String unSubTopic : unSubTopicList) {
+            for (final String unSubTopic : unSubTopicList) {
                 isChange = isChange
                         || removeSubscriptionByTopic(consumerGroup,
                         unSubscribeUrl,
                         unSubscribeRequestHeader.getIdc(),
                         unSubTopic);
-                ;
             }
         } finally {
-            lock.writeLock().unlock();
+            READ_WRITE_LOCK.writeLock().unlock();
         }
         return isChange;
     }
 
-    private void registerClientForUnsub(UnSubscribeRequestHeader unSubscribeRequestHeader,
-                                        String consumerGroup,
-                                        final List<String> topicList, String url) {
-        for (String topic : topicList) {
-            Client client = new Client();
+    private void registerClientForUnsub(final UnSubscribeRequestHeader unSubscribeRequestHeader,
+                                        final String consumerGroup,
+                                        final List<String> topicList,
+                                        final String url) {
+        Objects.requireNonNull(topicList, "topicList can not be null");
+        Objects.requireNonNull(unSubscribeRequestHeader, "unSubscribeRequestHeader can not be null");
+        Objects.requireNonNull(consumerGroup, "consumerGroup can not be null");
+        Objects.requireNonNull(url, "url can not be null");
+
+        for (final String topic : topicList) {
+            final Client client = new Client();
             client.setEnv(unSubscribeRequestHeader.getEnv());
             client.setIdc(unSubscribeRequestHeader.getIdc());
             client.setSys(unSubscribeRequestHeader.getSys());
@@ -418,13 +464,13 @@ public class HttpClientGroupMapping {
             client.setTopic(topic);
             client.setUrl(url);
             client.setLastUpTime(new Date());
-            String groupTopicKey = client.getConsumerGroup() + "@" + client.getTopic();
+            final String groupTopicKey = client.getConsumerGroup() + "@" + client.getTopic();
 
             if (localClientInfoMapping.containsKey(groupTopicKey)) {
-                List<Client> localClients =
+                final List<Client> localClients =
                         localClientInfoMapping.get(groupTopicKey);
                 boolean isContains = false;
-                for (Client localClient : localClients) {
+                for (final Client localClient : localClients) {
                     if (StringUtils.equals(localClient.getUrl(), client.getUrl())) {
                         isContains = true;
                         localClient.setLastUpTime(client.getLastUpTime());
@@ -436,7 +482,7 @@ public class HttpClientGroupMapping {
                     localClients.add(client);
                 }
             } else {
-                List<Client> clients = new ArrayList<>();
+                final List<Client> clients = new ArrayList<>();
                 clients.add(client);
                 localClientInfoMapping.put(groupTopicKey, clients);
             }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/HttpClientGroupMapping.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/HttpClientGroupMapping.java
@@ -31,7 +31,7 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -46,7 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class HttpClientGroupMapping {
-    private static final Logger HTTP_LOGGER = LoggerFactory.getLogger("http");
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpClientGroupMapping.class);
 
     private final transient ConcurrentHashMap<String /**group*/, ConsumerGroupConf> localConsumerGroupMapping =
             new ConcurrentHashMap<>();
@@ -200,7 +200,7 @@ public class HttpClientGroupMapping {
             consumeTopicConfig.setConsumerGroup(consumerGroup);
             consumeTopicConfig.setTopic(subTopic.getTopic());
             consumeTopicConfig.setSubscriptionItem(subTopic);
-            consumeTopicConfig.setUrls(new HashSet<>(Arrays.asList(url)));
+            consumeTopicConfig.setUrls(new HashSet<>(Collections.singletonList(url)));
             Map<String, List<String>> idcUrls = new HashMap<>();
             List<String> urls = new ArrayList<String>();
             urls.add(url);
@@ -221,7 +221,7 @@ public class HttpClientGroupMapping {
                 newTopicConf.setConsumerGroup(consumerGroup);
                 newTopicConf.setTopic(subTopic.getTopic());
                 newTopicConf.setSubscriptionItem(subTopic);
-                newTopicConf.setUrls(new HashSet<>(Arrays.asList(url)));
+                newTopicConf.setUrls(new HashSet<>(Collections.singletonList(url)));
                 Map<String, List<String>> idcUrls = new HashMap<>();
                 List<String> urls = new ArrayList<String>();
                 urls.add(url);
@@ -233,11 +233,15 @@ public class HttpClientGroupMapping {
                 ConsumerGroupTopicConf currentTopicConf = map.get(subTopic.getTopic());
                 if (!currentTopicConf.getUrls().add(url)) {
                     isChange = true;
-                    HTTP_LOGGER.info("add subscribe success, group:{}, url:{} , topic:{}", consumerGroup, url,
-                            subTopic.getTopic());
+                    if (LOGGER.isInfoEnabled()) {
+                        LOGGER.info("add subscribe success, group:{}, url:{} , topic:{}", consumerGroup, url,
+                                subTopic.getTopic());
+                    }
                 } else {
-                    HTTP_LOGGER.warn("The group has subscribed, group:{}, url:{} , topic:{}", consumerGroup, url,
-                            subTopic.getTopic());
+                    if (LOGGER.isWarnEnabled()) {
+                        LOGGER.warn("The group has subscribed, group:{}, url:{} , topic:{}", consumerGroup, url,
+                                subTopic.getTopic());
+                    }
                 }
 
                 if (!currentTopicConf.getIdcUrls().containsKey(clientIdc)) {
@@ -245,18 +249,24 @@ public class HttpClientGroupMapping {
                     urls.add(url);
                     currentTopicConf.getIdcUrls().put(clientIdc, urls);
                     isChange = true;
-                    HTTP_LOGGER.info("add url to idcUrlMap success, group:{}, url:{}, topic:{}, clientIdc:{}",
-                            consumerGroup, url, subTopic.getTopic(), clientIdc);
+                    if (LOGGER.isInfoEnabled()) {
+                        LOGGER.info("add url to idcUrlMap success, group:{}, url:{}, topic:{}, clientIdc:{}",
+                                consumerGroup, url, subTopic.getTopic(), clientIdc);
+                    }
                 } else {
                     Set<String> tmpSet = new HashSet<>(currentTopicConf.getIdcUrls().get(clientIdc));
                     if (!tmpSet.contains(url)) {
                         currentTopicConf.getIdcUrls().get(clientIdc).add(url);
                         isChange = true;
-                        HTTP_LOGGER.info("add url to idcUrlMap success, group:{}, url:{}, topic:{}, clientIdc:{}",
-                                consumerGroup, url, subTopic.getTopic(), clientIdc);
+                        if (LOGGER.isInfoEnabled()) {
+                            LOGGER.info("add url to idcUrlMap success, group:{}, url:{}, topic:{}, clientIdc:{}",
+                                    consumerGroup, url, subTopic.getTopic(), clientIdc);
+                        }
                     } else {
-                        HTTP_LOGGER.warn("The idcUrlMap has contains url, group:{}, url:{} , topic:{}, clientIdc:{}",
-                                consumerGroup, url, subTopic.getTopic(), clientIdc);
+                        if (LOGGER.isWarnEnabled()) {
+                            LOGGER.warn("The idcUrlMap has contains url, group:{}, url:{} , topic:{}, clientIdc:{}",
+                                    consumerGroup, url, subTopic.getTopic(), clientIdc);
+                        }
                     }
                 }
             }
@@ -269,57 +279,75 @@ public class HttpClientGroupMapping {
         boolean isChange = false;
         ConsumerGroupConf consumerGroupConf = localConsumerGroupMapping.get(consumerGroup);
         if (consumerGroupConf == null) {
-            HTTP_LOGGER.warn("unsubscribe fail, the current mesh does not have group subscriptionInfo, group:{}, url:{}",
-                    consumerGroup, unSubscribeUrl);
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn("unsubscribe fail, the current mesh does not have group subscriptionInfo, group:{}, url:{}",
+                        consumerGroup, unSubscribeUrl);
+            }
             return false;
         }
 
         ConsumerGroupTopicConf consumerGroupTopicConf = consumerGroupConf.getConsumerGroupTopicConf().get(unSubTopic);
         if (consumerGroupTopicConf == null) {
-            HTTP_LOGGER.warn(
-                    "unsubscribe fail, the current mesh does not have group-topic subscriptionInfo, group:{}, topic:{}, url:{}",
-                    consumerGroup, unSubTopic, unSubscribeUrl);
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn(
+                        "unsubscribe fail, the current mesh does not have group-topic subscriptionInfo, group:{}, topic:{}, url:{}",
+                        consumerGroup, unSubTopic, unSubscribeUrl);
+            }
             return false;
         }
 
         if (consumerGroupTopicConf.getUrls().remove(unSubscribeUrl)) {
             isChange = true;
-            HTTP_LOGGER.info("remove url success, group:{}, topic:{}, url:{}", consumerGroup, unSubTopic, unSubscribeUrl);
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.info("remove url success, group:{}, topic:{}, url:{}", consumerGroup, unSubTopic, unSubscribeUrl);
+            }
         } else {
-            HTTP_LOGGER.warn("remove url fail, not exist subscrition of this url, group:{}, topic:{}, url:{}",
-                    consumerGroup, unSubTopic, unSubscribeUrl);
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn("remove url fail, not exist subscrition of this url, group:{}, topic:{}, url:{}",
+                        consumerGroup, unSubTopic, unSubscribeUrl);
+            }
         }
 
         if (consumerGroupTopicConf.getIdcUrls().containsKey(clientIdc)) {
             if (consumerGroupTopicConf.getIdcUrls().get(clientIdc).remove(unSubscribeUrl)) {
                 isChange = true;
-                HTTP_LOGGER.info("remove url from idcUrlMap success, group:{}, topic:{}, url:{}, clientIdc:{}",
-                        consumerGroup, unSubTopic, unSubscribeUrl, clientIdc);
+                if (LOGGER.isInfoEnabled()) {
+                    LOGGER.info("remove url from idcUrlMap success, group:{}, topic:{}, url:{}, clientIdc:{}",
+                            consumerGroup, unSubTopic, unSubscribeUrl, clientIdc);
+                }
             } else {
-                HTTP_LOGGER.warn(
-                        "remove url from idcUrlMap fail,not exist subscrition of this url, group:{}, topic:{}, url:{}, clientIdc:{}",
-                        consumerGroup, unSubTopic, unSubscribeUrl, clientIdc);
+                if (LOGGER.isWarnEnabled()) {
+                    LOGGER.warn(
+                            "remove url from idcUrlMap fail,not exist subscrition of this url, group:{}, topic:{}, url:{}, clientIdc:{}",
+                            consumerGroup, unSubTopic, unSubscribeUrl, clientIdc);
+                }
             }
         } else {
-            HTTP_LOGGER.warn(
-                    "remove url from idcUrlMap fail,not exist subscrition of this idc , group:{}, topic:{}, url:{}, clientIdc:{}",
-                    consumerGroup, unSubTopic, unSubscribeUrl, clientIdc);
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn(
+                        "remove url from idcUrlMap fail,not exist subscrition of this idc , group:{}, topic:{}, url:{}, clientIdc:{}",
+                        consumerGroup, unSubTopic, unSubscribeUrl, clientIdc);
+            }
         }
 
         if (isChange && consumerGroupTopicConf.getUrls().size() == 0) {
             consumerGroupConf.getConsumerGroupTopicConf().remove(unSubTopic);
-            HTTP_LOGGER.info("group unsubscribe topic success,group:{}, topic:{}", consumerGroup, unSubTopic);
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.info("group unsubscribe topic success,group:{}, topic:{}", consumerGroup, unSubTopic);
+            }
         }
-        
+
         if (isChange && consumerGroupConf.getConsumerGroupTopicConf().size() == 0) {
             localConsumerGroupMapping.remove(consumerGroup);
-            HTTP_LOGGER.info("group unsubscribe success,group:{}", consumerGroup);
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.info("group unsubscribe success,group:{}", consumerGroup);
+            }
         }
         return isChange;
     }
 
-    private void registerClientForSub(SubscribeRequestHeader subscribeRequestHeader, String consumerGroup,
-                                      final List<SubscriptionItem> subscriptionItems, String url) {
+    private void registerClientForSub(final SubscribeRequestHeader subscribeRequestHeader, final String consumerGroup,
+                                      final List<SubscriptionItem> subscriptionItems, final String url) {
         for (SubscriptionItem item : subscriptionItems) {
             Client client = new Client();
             client.env = subscribeRequestHeader.getEnv();

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/HeartBeatProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/HeartBeatProcessor.java
@@ -115,18 +115,18 @@ public class HeartBeatProcessor implements HttpRequestProcessor {
         for (HeartbeatRequestBody.HeartbeatEntity heartbeatEntity : heartbeatEntities) {
 
             Client client = new Client();
-            client.env = env;
-            client.idc = idc;
-            client.sys = sys;
-            client.ip = ip;
-            client.pid = pid;
-            client.consumerGroup = consumerGroup;
-            client.topic = heartbeatEntity.topic;
-            client.url = heartbeatEntity.url;
+            client.setEnv(env);
+            client.setIdc(idc);
+            client.setSys(sys);
+            client.setIp(ip);
+            client.setPid(pid);
+            client.setConsumerGroup(consumerGroup);
+            client.setTopic(heartbeatEntity.topic);
+            client.setUrl(heartbeatEntity.url);
 
-            client.lastUpTime = new Date();
+            client.setLastUpTime(new Date());
 
-            if (StringUtils.isBlank(client.topic)) {
+            if (StringUtils.isBlank(client.getTopic())) {
                 continue;
             }
 
@@ -137,7 +137,7 @@ public class HeartBeatProcessor implements HttpRequestProcessor {
                 String pass = heartbeatRequestHeader.getPasswd();
                 int requestCode = Integer.parseInt(heartbeatRequestHeader.getCode());
                 try {
-                    Acl.doAclCheckInHttpHeartbeat(remoteAddr, user, pass, sys, client.topic, requestCode);
+                    Acl.doAclCheckInHttpHeartbeat(remoteAddr, user, pass, sys, client.getTopic(), requestCode);
                 } catch (Exception e) {
                     responseEventMeshCommand = asyncContext.getRequest().createHttpCommandResponse(
                             heartbeatResponseHeader,
@@ -149,11 +149,11 @@ public class HeartBeatProcessor implements HttpRequestProcessor {
                 }
             }
 
-            if (StringUtils.isBlank(client.url)) {
+            if (StringUtils.isBlank(client.getUrl())) {
                 continue;
             }
 
-            String groupTopicKey = client.consumerGroup + "@" + client.topic;
+            String groupTopicKey = client.getConsumerGroup() + "@" + client.getTopic();
 
             if (tmp.containsKey(groupTopicKey)) {
                 tmp.get(groupTopicKey).add(client);
@@ -219,9 +219,9 @@ public class HeartBeatProcessor implements HttpRequestProcessor {
         for (Client tmpClient : tmpClientList) {
             boolean isContains = false;
             for (Client localClient : localClientList) {
-                if (StringUtils.equals(localClient.url, tmpClient.url)) {
+                if (StringUtils.equals(localClient.getUrl(), tmpClient.getUrl())) {
                     isContains = true;
-                    localClient.lastUpTime = tmpClient.lastUpTime;
+                    localClient.setLastUpTime(tmpClient.getLastUpTime());
                     break;
                 }
             }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalSubscribeEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalSubscribeEventProcessor.java
@@ -31,7 +31,6 @@ import org.apache.eventmesh.runtime.common.EventMeshTrace;
 import org.apache.eventmesh.runtime.constants.EventMeshConstants;
 import org.apache.eventmesh.runtime.core.consumergroup.ConsumerGroupConf;
 import org.apache.eventmesh.runtime.core.consumergroup.ConsumerGroupTopicConf;
-import org.apache.eventmesh.runtime.core.protocol.http.async.AsyncContext;
 import org.apache.eventmesh.runtime.core.protocol.http.processor.inf.AbstractEventProcessor;
 import org.apache.eventmesh.runtime.core.protocol.http.processor.inf.Client;
 import org.apache.eventmesh.runtime.util.RemotingHelper;
@@ -48,12 +47,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.Channel;
 import io.netty.handler.codec.http.HttpRequest;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -62,86 +60,85 @@ import com.fasterxml.jackson.core.type.TypeReference;
 @EventMeshTrace(isEnable = false)
 public class LocalSubscribeEventProcessor extends AbstractEventProcessor {
 
-    public Logger httpLogger = LoggerFactory.getLogger("http");
+    private static final Logger LOGGER = LoggerFactory.getLogger(LocalSubscribeEventProcessor.class);
 
-    public Logger aclLogger = LoggerFactory.getLogger("acl");
-
-    public LocalSubscribeEventProcessor(EventMeshHTTPServer eventMeshHTTPServer) {
+    public LocalSubscribeEventProcessor(final EventMeshHTTPServer eventMeshHTTPServer) {
         super(eventMeshHTTPServer);
     }
 
     @Override
-    public void handler(HandlerService.HandlerSpecific handlerSpecific, HttpRequest httpRequest) throws Exception {
+    public void handler(final HandlerService.HandlerSpecific handlerSpecific, final HttpRequest httpRequest)
+            throws Exception {
 
-        AsyncContext<HttpEventWrapper> asyncContext = handlerSpecific.getAsyncContext();
+        final Channel channel = handlerSpecific.getCtx().channel();
+        final HttpEventWrapper requestWrapper = handlerSpecific.getAsyncContext().getRequest();
 
-        ChannelHandlerContext ctx = handlerSpecific.getCtx();
-
-        HttpEventWrapper requestWrapper = asyncContext.getRequest();
-
-        httpLogger.info("uri={}|{}|client2eventMesh|from={}|to={}", requestWrapper.getRequestURI(),
-            EventMeshConstants.PROTOCOL_HTTP, RemotingHelper.parseChannelRemoteAddr(ctx.channel()), IPUtils.getLocalAddress()
-        );
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("uri={}|{}|client2eventMesh|from={}|to={}", requestWrapper.getRequestURI(),
+                    EventMeshConstants.PROTOCOL_HTTP, RemotingHelper.parseChannelRemoteAddr(channel),
+                    IPUtils.getLocalAddress());
+        }
 
         // user request header
-        Map<String, Object> userRequestHeaderMap = requestWrapper.getHeaderMap();
-        String requestIp = RemotingHelper.parseChannelRemoteAddr(ctx.channel());
-        userRequestHeaderMap.put(ProtocolKey.ClientInstanceKey.IP, requestIp);
-
+        requestWrapper.getHeaderMap().put(ProtocolKey.ClientInstanceKey.IP,
+                RemotingHelper.parseChannelRemoteAddr(channel));
         // build sys header
         requestWrapper.buildSysHeaderForClient();
 
-        Map<String, Object> responseHeaderMap = builderResponseHeaderMap(requestWrapper);
-
-        Map<String, Object> sysHeaderMap = requestWrapper.getSysHeaderMap();
-
-        Map<String, Object> responseBodyMap = new HashMap<>();
+        final Map<String, Object> responseHeaderMap = builderResponseHeaderMap(requestWrapper);
+        final Map<String, Object> sysHeaderMap = requestWrapper.getSysHeaderMap();
+        final Map<String, Object> responseBodyMap = new HashMap<>();
 
         //validate header
         if (validateSysHeader(sysHeaderMap)) {
             handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR, responseHeaderMap,
-                responseBodyMap, null);
+                    responseBodyMap, null);
             return;
         }
 
         //validate body
-        byte[] requestBody = requestWrapper.getBody();
+        final Map<String, Object> requestBodyMap = Optional.ofNullable(JsonUtils.deserialize(
+                new String(requestWrapper.getBody(), Constants.DEFAULT_CHARSET),
+                new TypeReference<HashMap<String, Object>>() {
+                }
+        )).orElseGet(HashMap::new);
 
-        Map<String, Object> requestBodyMap = Optional.ofNullable(JsonUtils.deserialize(
-            new String(requestBody, Constants.DEFAULT_CHARSET),
-            new TypeReference<HashMap<String, Object>>() {}
-        )).orElse(new HashMap<>());
-
-        if (requestBodyMap.get("url") == null || requestBodyMap.get("topic") == null || requestBodyMap.get("consumerGroup") == null) {
+        if (requestBodyMap.get("url") == null
+                || requestBodyMap.get("topic") == null
+                || requestBodyMap.get("consumerGroup") == null) {
             handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR, responseHeaderMap,
-                responseBodyMap, null);
+                    responseBodyMap, null);
             return;
         }
 
-        String url = requestBodyMap.get("url").toString();
-        String consumerGroup = requestBodyMap.get("consumerGroup").toString();
-        String topic = JsonUtils.serialize(requestBodyMap.get("topic"));
+        final String url = requestBodyMap.get("url").toString();
+        final String consumerGroup = requestBodyMap.get("consumerGroup").toString();
+        final String topic = JsonUtils.serialize(requestBodyMap.get("topic"));
 
         // SubscriptionItem
-        List<SubscriptionItem> subscriptionList = Optional.ofNullable(JsonUtils.deserialize(
-            topic,
-            new TypeReference<List<SubscriptionItem>>() {}
-        )).orElse(Collections.emptyList());
+        final List<SubscriptionItem> subscriptionList = Optional.ofNullable(JsonUtils.deserialize(
+                topic,
+                new TypeReference<List<SubscriptionItem>>() {
+                }
+        )).orElseGet(Collections::emptyList);
 
         //do acl check
         if (eventMeshHTTPServer.getEventMeshHttpConfiguration().isEventMeshServerSecurityEnable()) {
-            String remoteAddr = RemotingHelper.parseChannelRemoteAddr(ctx.channel());
-            String user = sysHeaderMap.get(ProtocolKey.ClientInstanceKey.USERNAME).toString();
-            String pass = sysHeaderMap.get(ProtocolKey.ClientInstanceKey.PASSWD).toString();
-            String subsystem = sysHeaderMap.get(ProtocolKey.ClientInstanceKey.SYS).toString();
-            for (SubscriptionItem item : subscriptionList) {
+            for (final SubscriptionItem item : subscriptionList) {
                 try {
-                    Acl.doAclCheckInHttpReceive(remoteAddr, user, pass, subsystem, item.getTopic(),
-                        requestWrapper.getRequestURI());
+                    Acl.doAclCheckInHttpReceive(RemotingHelper.parseChannelRemoteAddr(channel),
+                            sysHeaderMap.get(ProtocolKey.ClientInstanceKey.USERNAME).toString(),
+                            sysHeaderMap.get(ProtocolKey.ClientInstanceKey.PASSWD).toString(),
+                            sysHeaderMap.get(ProtocolKey.ClientInstanceKey.SYS).toString(),
+                            item.getTopic(),
+                            requestWrapper.getRequestURI());
                 } catch (Exception e) {
-                    aclLogger.warn("CLIENT HAS NO PERMISSION,SubscribeProcessor subscribe failed", e);
+                    if (LOGGER.isWarnEnabled()) {
+                        LOGGER.warn("CLIENT HAS NO PERMISSION,SubscribeProcessor subscribe failed", e);
+                    }
+
                     handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_ACL_ERR, responseHeaderMap,
-                        responseBodyMap, null);
+                            responseBodyMap, null);
                     return;
                 }
             }
@@ -150,27 +147,25 @@ public class LocalSubscribeEventProcessor extends AbstractEventProcessor {
         // validate URL
         try {
             if (!IPUtils.isValidDomainOrIp(url, eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshIpv4BlackList,
-                eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshIpv6BlackList)) {
-                httpLogger.error("subscriber url {} is not valid", url);
+                    eventMeshHTTPServer.getEventMeshHttpConfiguration().eventMeshIpv6BlackList)) {
+                LOGGER.error("subscriber url {} is not valid", url);
                 handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR, responseHeaderMap,
-                    responseBodyMap, null);
+                        responseBodyMap, null);
                 return;
             }
         } catch (Exception e) {
-            httpLogger.error("subscriber url {} is not valid, error {}", url, e.getMessage());
+            LOGGER.error("subscriber url is invalid, url:" + url, e);
             handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR, responseHeaderMap,
-                responseBodyMap, null);
+                    responseBodyMap, null);
             return;
         }
 
         // obtain webhook delivery agreement for Abuse Protection
-        boolean isWebhookAllowed = WebhookUtil.obtainDeliveryAgreement(eventMeshHTTPServer.httpClientPool.getClient(),
-            url, eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshWebhookOrigin());
-
-        if (!isWebhookAllowed) {
-            httpLogger.error("subscriber url {} is not allowed by the target system", url);
+        if (!WebhookUtil.obtainDeliveryAgreement(eventMeshHTTPServer.httpClientPool.getClient(),
+                url, eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshWebhookOrigin())) {
+            LOGGER.error("subscriber url {} is not allowed by the target system", url);
             handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR, responseHeaderMap,
-                responseBodyMap, null);
+                    responseBodyMap, null);
             return;
         }
 
@@ -178,47 +173,47 @@ public class LocalSubscribeEventProcessor extends AbstractEventProcessor {
 
             registerClient(requestWrapper, consumerGroup, subscriptionList, url);
 
-            for (SubscriptionItem subTopic : subscriptionList) {
-                List<Client> groupTopicClients = eventMeshHTTPServer.localClientInfoMapping
-                    .get(consumerGroup + "@" + subTopic.getTopic());
+            for (final SubscriptionItem subTopic : subscriptionList) {
+                final List<Client> groupTopicClients = eventMeshHTTPServer.localClientInfoMapping
+                        .get(consumerGroup + "@" + subTopic.getTopic());
 
                 if (CollectionUtils.isEmpty(groupTopicClients)) {
-                    httpLogger.error("group {} topic {} clients is empty", consumerGroup, subTopic);
+                    LOGGER.error("group {} topic {} clients is empty", consumerGroup, subTopic);
                 }
 
-                Map<String, List<String>> idcUrls = new HashMap<>();
-                for (Client client : groupTopicClients) {
-                    if (idcUrls.containsKey(client.idc)) {
-                        idcUrls.get(client.idc).add(StringUtils.deleteWhitespace(client.url));
+                final Map<String, List<String>> idcUrls = new HashMap<>();
+                for (final Client client : groupTopicClients) {
+                    if (idcUrls.containsKey(client.getIdc())) {
+                        idcUrls.get(client.getIdc()).add(StringUtils.deleteWhitespace(client.getUrl()));
                     } else {
-                        List<String> urls = new ArrayList<>();
-                        urls.add(client.url);
-                        idcUrls.put(client.idc, urls);
+                        final List<String> urls = new ArrayList<>();
+                        urls.add(client.getUrl());
+                        idcUrls.put(client.getIdc(), urls);
                     }
                 }
+
                 ConsumerGroupConf consumerGroupConf =
-                    eventMeshHTTPServer.localConsumerGroupMapping.get(consumerGroup);
+                        eventMeshHTTPServer.localConsumerGroupMapping.get(consumerGroup);
                 if (consumerGroupConf == null) {
                     // new subscription
                     consumerGroupConf = new ConsumerGroupConf(consumerGroup);
-                    ConsumerGroupTopicConf consumeTopicConfig = new ConsumerGroupTopicConf();
+                    final ConsumerGroupTopicConf consumeTopicConfig = new ConsumerGroupTopicConf();
                     consumeTopicConfig.setConsumerGroup(consumerGroup);
                     consumeTopicConfig.setTopic(subTopic.getTopic());
                     consumeTopicConfig.setSubscriptionItem(subTopic);
                     consumeTopicConfig.setUrls(new HashSet<>(Collections.singletonList(url)));
-
                     consumeTopicConfig.setIdcUrls(idcUrls);
 
-                    Map<String, ConsumerGroupTopicConf> map = new HashMap<>();
+                    final Map<String, ConsumerGroupTopicConf> map = new HashMap<>();
                     map.put(subTopic.getTopic(), consumeTopicConfig);
                     consumerGroupConf.setConsumerGroupTopicConf(map);
                 } else {
                     // already subscribed
-                    Map<String, ConsumerGroupTopicConf> map =
-                        consumerGroupConf.getConsumerGroupTopicConf();
+                    final Map<String, ConsumerGroupTopicConf> map =
+                            consumerGroupConf.getConsumerGroupTopicConf();
                     if (!map.containsKey(subTopic.getTopic())) {
                         //If there are multiple topics, append it
-                        ConsumerGroupTopicConf newTopicConf = new ConsumerGroupTopicConf();
+                        final ConsumerGroupTopicConf newTopicConf = new ConsumerGroupTopicConf();
                         newTopicConf.setConsumerGroup(consumerGroup);
                         newTopicConf.setTopic(subTopic.getTopic());
                         newTopicConf.setSubscriptionItem(subTopic);
@@ -226,19 +221,19 @@ public class LocalSubscribeEventProcessor extends AbstractEventProcessor {
                         newTopicConf.setIdcUrls(idcUrls);
                         map.put(subTopic.getTopic(), newTopicConf);
                     }
-                    Set<Map.Entry<String, ConsumerGroupTopicConf>> entrySet = map.entrySet();
-                    for (Map.Entry<String, ConsumerGroupTopicConf> set : entrySet) {
+
+                    for (final Map.Entry<String, ConsumerGroupTopicConf> set : map.entrySet()) {
                         if (!StringUtils.equals(subTopic.getTopic(), set.getKey())) {
                             continue;
                         }
 
-                        ConsumerGroupTopicConf latestTopicConf = new ConsumerGroupTopicConf();
+                        final ConsumerGroupTopicConf latestTopicConf = new ConsumerGroupTopicConf();
                         latestTopicConf.setConsumerGroup(consumerGroup);
                         latestTopicConf.setTopic(subTopic.getTopic());
                         latestTopicConf.setSubscriptionItem(subTopic);
                         latestTopicConf.setUrls(new HashSet<>(Collections.singletonList(url)));
 
-                        ConsumerGroupTopicConf currentTopicConf = set.getValue();
+                        final ConsumerGroupTopicConf currentTopicConf = set.getValue();
                         latestTopicConf.getUrls().addAll(currentTopicConf.getUrls());
                         latestTopicConf.setIdcUrls(idcUrls);
 
@@ -248,24 +243,22 @@ public class LocalSubscribeEventProcessor extends AbstractEventProcessor {
                 eventMeshHTTPServer.localConsumerGroupMapping.put(consumerGroup, consumerGroupConf);
             }
 
-            long startTime = System.currentTimeMillis();
+            final long startTime = System.currentTimeMillis();
             try {
                 // subscription relationship change notification
                 eventMeshHTTPServer.getConsumerManager().notifyConsumerManager(consumerGroup,
-                    eventMeshHTTPServer.localConsumerGroupMapping.get(consumerGroup));
-
+                        eventMeshHTTPServer.localConsumerGroupMapping.get(consumerGroup));
                 responseBodyMap.put("retCode", EventMeshRetCode.SUCCESS.getRetCode());
                 responseBodyMap.put("retMsg", EventMeshRetCode.SUCCESS.getErrMsg());
 
                 handlerSpecific.sendResponse(responseHeaderMap, responseBodyMap);
 
             } catch (Exception e) {
-                long endTime = System.currentTimeMillis();
-                httpLogger.error(
-                    "message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}"
-                        + "|bizSeqNo={}|uniqueId={}", endTime - startTime,
-                    JsonUtils.serialize(subscriptionList), url, e);
-                handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_SUBSCRIBE_ERR, responseHeaderMap, responseBodyMap, null);
+                LOGGER.error(String.format("message|eventMesh2mq|REQ|ASYNC|send2MQCost=%s ms|topic=%s"
+                                + "|uniqueId=%s", System.currentTimeMillis() - startTime,
+                        JsonUtils.serialize(subscriptionList), url), e);
+                handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_SUBSCRIBE_ERR, responseHeaderMap,
+                        responseBodyMap, null);
             }
 
             // Update service metadata
@@ -276,42 +269,43 @@ public class LocalSubscribeEventProcessor extends AbstractEventProcessor {
 
     @Override
     public String[] paths() {
-        return new String[] {RequestURI.SUBSCRIBE_LOCAL.getRequestURI()};
+        return new String[]{RequestURI.SUBSCRIBE_LOCAL.getRequestURI()};
     }
 
-    private void registerClient(HttpEventWrapper requestWrapper, String consumerGroup,
-                                List<SubscriptionItem> subscriptionItems, String url) {
-        Map<String, Object> requestHeaderMap = requestWrapper.getSysHeaderMap();
-        for (SubscriptionItem item : subscriptionItems) {
-            Client client = new Client();
-            client.env = requestHeaderMap.get(ProtocolKey.ClientInstanceKey.ENV).toString();
-            client.idc = requestHeaderMap.get(ProtocolKey.ClientInstanceKey.IDC).toString();
-            client.sys = requestHeaderMap.get(ProtocolKey.ClientInstanceKey.SYS).toString();
-            client.ip = requestHeaderMap.get(ProtocolKey.ClientInstanceKey.IP).toString();
-            client.pid = requestHeaderMap.get(ProtocolKey.ClientInstanceKey.PID).toString();
-            client.consumerGroup = consumerGroup;
-            client.topic = item.getTopic();
-            client.url = url;
-            client.lastUpTime = new Date();
+    private void registerClient(final HttpEventWrapper requestWrapper, final String consumerGroup,
+                                final List<SubscriptionItem> subscriptionItems, final String url) {
+        final Map<String, Object> requestHeaderMap = requestWrapper.getSysHeaderMap();
+        for (final SubscriptionItem item : subscriptionItems) {
+            final Client client = new Client();
+            client.setEnv(requestHeaderMap.get(ProtocolKey.ClientInstanceKey.ENV).toString());
+            client.setIdc(requestHeaderMap.get(ProtocolKey.ClientInstanceKey.IDC).toString());
+            client.setSys(requestHeaderMap.get(ProtocolKey.ClientInstanceKey.SYS).toString());
+            client.setIp(requestHeaderMap.get(ProtocolKey.ClientInstanceKey.IP).toString());
+            client.setPid(requestHeaderMap.get(ProtocolKey.ClientInstanceKey.PID).toString());
+            client.setConsumerGroup(consumerGroup);
+            client.setTopic(item.getTopic());
+            client.setUrl(url);
+            client.setLastUpTime(new Date());
 
-            String groupTopicKey = client.consumerGroup + "@" + client.topic;
+            final String groupTopicKey = client.getConsumerGroup() + "@" + client.getTopic();
 
             if (eventMeshHTTPServer.localClientInfoMapping.containsKey(groupTopicKey)) {
-                List<Client> localClients =
-                    eventMeshHTTPServer.localClientInfoMapping.get(groupTopicKey);
+                final List<Client> localClients =
+                        eventMeshHTTPServer.localClientInfoMapping.get(groupTopicKey);
                 boolean isContains = false;
-                for (Client localClient : localClients) {
-                    if (StringUtils.equals(localClient.url, client.url)) {
+                for (final Client localClient : localClients) {
+                    if (StringUtils.equals(localClient.getUrl(), client.getUrl())) {
                         isContains = true;
-                        localClient.lastUpTime = client.lastUpTime;
+                        localClient.setLastUpTime(client.getLastUpTime());
                         break;
                     }
                 }
+
                 if (!isContains) {
                     localClients.add(client);
                 }
             } else {
-                List<Client> clients = new ArrayList<>();
+                final List<Client> clients = new ArrayList<>();
                 clients.add(client);
                 eventMeshHTTPServer.localClientInfoMapping.put(groupTopicKey, clients);
             }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalUnSubscribeEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalUnSubscribeEventProcessor.java
@@ -142,8 +142,8 @@ public class LocalUnSubscribeEventProcessor extends AbstractEventProcessor {
                 Iterator<Client> clientIterator = groupTopicClients.iterator();
                 while (clientIterator.hasNext()) {
                     Client client = clientIterator.next();
-                    if (StringUtils.equals(client.pid, pid)
-                        && StringUtils.equals(client.url, unSubscribeUrl)) {
+                    if (StringUtils.equals(client.getPid(), pid)
+                        && StringUtils.equals(client.getUrl(), unSubscribeUrl)) {
                         httpLogger.warn("client {} start unsubscribe", JsonUtils.serialize(client));
                         clientIterator.remove();
                     }
@@ -154,15 +154,15 @@ public class LocalUnSubscribeEventProcessor extends AbstractEventProcessor {
                     Set<String> clientUrls = new HashSet<>();
                     for (Client client : groupTopicClients) {
                         // remove subscribed url
-                        if (!StringUtils.equals(unSubscribeUrl, client.url)) {
-                            clientUrls.add(client.url);
-                            if (idcUrls.containsKey(client.idc)) {
-                                idcUrls.get(client.idc)
-                                    .add(StringUtils.deleteWhitespace(client.url));
+                        if (!StringUtils.equals(unSubscribeUrl, client.getUrl())) {
+                            clientUrls.add(client.getUrl());
+                            if (idcUrls.containsKey(client.getIdc())) {
+                                idcUrls.get(client.getIdc())
+                                    .add(StringUtils.deleteWhitespace(client.getUrl()));
                             } else {
                                 List<String> urls = new ArrayList<>();
-                                urls.add(client.url);
-                                idcUrls.put(client.idc, urls);
+                                urls.add(client.getUrl());
+                                idcUrls.put(client.getIdc(), urls);
                             }
                         }
 
@@ -260,25 +260,25 @@ public class LocalUnSubscribeEventProcessor extends AbstractEventProcessor {
         Map<String, Object> requestHeaderMap = requestWrapper.getSysHeaderMap();
         for (String topic : topicList) {
             Client client = new Client();
-            client.env = requestHeaderMap.get(ProtocolKey.ClientInstanceKey.ENV).toString();
-            client.idc = requestHeaderMap.get(ProtocolKey.ClientInstanceKey.IDC).toString();
-            client.sys = requestHeaderMap.get(ProtocolKey.ClientInstanceKey.SYS).toString();
-            client.ip = requestHeaderMap.get(ProtocolKey.ClientInstanceKey.IP).toString();
-            client.pid = requestHeaderMap.get(ProtocolKey.ClientInstanceKey.PID).toString();
-            client.consumerGroup = consumerGroup;
-            client.topic = topic;
-            client.url = url;
-            client.lastUpTime = new Date();
+            client.setEnv(requestHeaderMap.get(ProtocolKey.ClientInstanceKey.ENV).toString());
+            client.setIdc(requestHeaderMap.get(ProtocolKey.ClientInstanceKey.IDC).toString());
+            client.setSys(requestHeaderMap.get(ProtocolKey.ClientInstanceKey.SYS).toString());
+            client.setIp(requestHeaderMap.get(ProtocolKey.ClientInstanceKey.IP).toString());
+            client.setPid(requestHeaderMap.get(ProtocolKey.ClientInstanceKey.PID).toString());
+            client.setConsumerGroup(consumerGroup);
+            client.setTopic(topic);
+            client.setUrl(url);
+            client.setLastUpTime(new Date());
 
-            String groupTopicKey = client.consumerGroup + "@" + client.topic;
+            String groupTopicKey = client.getConsumerGroup() + "@" + client.getTopic();
             if (eventMeshHTTPServer.localClientInfoMapping.containsKey(groupTopicKey)) {
                 List<Client> localClients =
                     eventMeshHTTPServer.localClientInfoMapping.get(groupTopicKey);
                 boolean isContains = false;
                 for (Client localClient : localClients) {
-                    if (StringUtils.equals(localClient.url, client.url)) {
+                    if (StringUtils.equals(localClient.getUrl(), client.getUrl())) {
                         isContains = true;
-                        localClient.lastUpTime = client.lastUpTime;
+                        localClient.setLastUpTime(client.getLastUpTime());
                         break;
                     }
                 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SubscribeProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SubscribeProcessor.java
@@ -202,12 +202,12 @@ public class SubscribeProcessor implements HttpRequestProcessor {
 
                 Map<String, List<String>> idcUrls = new HashMap<>();
                 for (Client client : groupTopicClients) {
-                    if (idcUrls.containsKey(client.idc)) {
-                        idcUrls.get(client.idc).add(StringUtils.deleteWhitespace(client.url));
+                    if (idcUrls.containsKey(client.getIdc())) {
+                        idcUrls.get(client.getIdc()).add(StringUtils.deleteWhitespace(client.getUrl()));
                     } else {
                         List<String> urls = new ArrayList<>();
-                        urls.add(client.url);
-                        idcUrls.put(client.idc, urls);
+                        urls.add(client.getUrl());
+                        idcUrls.put(client.getIdc(), urls);
                     }
                 }
                 ConsumerGroupConf consumerGroupConf =
@@ -312,26 +312,26 @@ public class SubscribeProcessor implements HttpRequestProcessor {
                                 List<SubscriptionItem> subscriptionItems, String url) {
         for (SubscriptionItem item : subscriptionItems) {
             Client client = new Client();
-            client.env = subscribeRequestHeader.getEnv();
-            client.idc = subscribeRequestHeader.getIdc();
-            client.sys = subscribeRequestHeader.getSys();
-            client.ip = subscribeRequestHeader.getIp();
-            client.pid = subscribeRequestHeader.getPid();
-            client.consumerGroup = consumerGroup;
-            client.topic = item.getTopic();
-            client.url = url;
-            client.lastUpTime = new Date();
+            client.setEnv(subscribeRequestHeader.getEnv());
+            client.setIdc(subscribeRequestHeader.getIdc());
+            client.setSys(subscribeRequestHeader.getSys());
+            client.setIp(subscribeRequestHeader.getIp());
+            client.setPid(subscribeRequestHeader.getPid());
+            client.setConsumerGroup(consumerGroup);
+            client.setTopic(item.getTopic());
+            client.setUrl(url);
+            client.setLastUpTime(new Date());
 
-            String groupTopicKey = client.consumerGroup + "@" + client.topic;
+            String groupTopicKey = client.getConsumerGroup() + "@" + client.getTopic();
 
             if (eventMeshHTTPServer.localClientInfoMapping.containsKey(groupTopicKey)) {
                 List<Client> localClients =
                     eventMeshHTTPServer.localClientInfoMapping.get(groupTopicKey);
                 boolean isContains = false;
                 for (Client localClient : localClients) {
-                    if (StringUtils.equals(localClient.url, client.url)) {
+                    if (StringUtils.equals(localClient.getUrl(), client.getUrl())) {
                         isContains = true;
-                        localClient.lastUpTime = client.lastUpTime;
+                        localClient.setLastUpTime(client.getLastUpTime());
                         break;
                     }
                 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/UnSubscribeProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/UnSubscribeProcessor.java
@@ -148,8 +148,8 @@ public class UnSubscribeProcessor implements HttpRequestProcessor {
                 Iterator<Client> clientIterator = groupTopicClients.iterator();
                 while (clientIterator.hasNext()) {
                     Client client = clientIterator.next();
-                    if (StringUtils.equals(client.pid, pid)
-                            && StringUtils.equals(client.url, unSubscribeUrl)) {
+                    if (StringUtils.equals(client.getPid(), pid)
+                            && StringUtils.equals(client.getUrl(), unSubscribeUrl)) {
                         httpLogger.warn("client {} start unsubscribe", JsonUtils.serialize(client));
                         clientIterator.remove();
                     }
@@ -160,15 +160,15 @@ public class UnSubscribeProcessor implements HttpRequestProcessor {
                     Set<String> clientUrls = new HashSet<>();
                     for (Client client : groupTopicClients) {
                         // remove subscribed url
-                        if (!StringUtils.equals(unSubscribeUrl, client.url)) {
-                            clientUrls.add(client.url);
-                            if (idcUrls.containsKey(client.idc)) {
-                                idcUrls.get(client.idc)
-                                        .add(StringUtils.deleteWhitespace(client.url));
+                        if (!StringUtils.equals(unSubscribeUrl, client.getUrl())) {
+                            clientUrls.add(client.getUrl());
+                            if (idcUrls.containsKey(client.getIdc())) {
+                                idcUrls.get(client.getIdc())
+                                        .add(StringUtils.deleteWhitespace(client.getUrl()));
                             } else {
                                 List<String> urls = new ArrayList<>();
-                                urls.add(client.url);
-                                idcUrls.put(client.idc, urls);
+                                urls.add(client.getUrl());
+                                idcUrls.put(client.getIdc(), urls);
                             }
                         }
 
@@ -275,25 +275,25 @@ public class UnSubscribeProcessor implements HttpRequestProcessor {
                                 List<String> topicList, String url) {
         for (String topic : topicList) {
             Client client = new Client();
-            client.env = unSubscribeRequestHeader.getEnv();
-            client.idc = unSubscribeRequestHeader.getIdc();
-            client.sys = unSubscribeRequestHeader.getSys();
-            client.ip = unSubscribeRequestHeader.getIp();
-            client.pid = unSubscribeRequestHeader.getPid();
-            client.consumerGroup = consumerGroup;
-            client.topic = topic;
-            client.url = url;
-            client.lastUpTime = new Date();
+            client.setEnv(unSubscribeRequestHeader.getEnv());
+            client.setIdc(unSubscribeRequestHeader.getIdc());
+            client.setSys(unSubscribeRequestHeader.getSys());
+            client.setIp(unSubscribeRequestHeader.getIp());
+            client.setPid(unSubscribeRequestHeader.getPid());
+            client.setConsumerGroup(consumerGroup);
+            client.setTopic(topic);
+            client.setUrl(url);
+            client.setLastUpTime(new Date());
 
-            String groupTopicKey = client.consumerGroup + "@" + client.topic;
+            String groupTopicKey = client.getConsumerGroup() + "@" + client.getTopic();
             if (eventMeshHTTPServer.localClientInfoMapping.containsKey(groupTopicKey)) {
                 List<Client> localClients =
                         eventMeshHTTPServer.localClientInfoMapping.get(groupTopicKey);
                 boolean isContains = false;
                 for (Client localClient : localClients) {
-                    if (StringUtils.equals(localClient.url, client.url)) {
+                    if (StringUtils.equals(localClient.getUrl(), client.getUrl())) {
                         isContains = true;
-                        localClient.lastUpTime = client.lastUpTime;
+                        localClient.setLastUpTime(client.getLastUpTime());
                         break;
                     }
                 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/UnSubscribeProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/UnSubscribeProcessor.java
@@ -164,12 +164,10 @@ public class UnSubscribeProcessor implements HttpRequestProcessor {
                         // remove subscribed url
                         if (!StringUtils.equals(unSubscribeUrl, client.getUrl())) {
                             clientUrls.add(client.getUrl());
-                            if (idcUrls.containsKey(client.getIdc())) {
-                                idcUrls.get(client.getIdc())
-                                        .add(StringUtils.deleteWhitespace(client.getUrl()));
-                            } else {
-                                final List<String> urls = new ArrayList<>();
-                                urls.add(client.getUrl());
+
+                            List<String> urls = idcUrls.get(client.getIdc());
+                            if (urls == null) {
+                                urls = new ArrayList<String>();
                                 idcUrls.put(client.getIdc(), urls);
                             }
                         }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/inf/Client.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/inf/Client.java
@@ -23,27 +23,116 @@ import java.util.Date;
 
 public class Client {
 
-    public String env;
+    private String env;
 
-    public String idc;
+    private String idc;
 
-    public String consumerGroup;
+    private String consumerGroup;
 
-    public String topic;
+    private String topic;
 
-    public String url;
+    private String url;
 
-    public String sys;
+    private String sys;
 
-    public String ip;
+    private String ip;
 
-    public String pid;
+    private String pid;
 
-    public String hostname;
+    private String hostname;
 
-    public String apiVersion;
+    private Date lastUpTime;
 
-    public Date lastUpTime;
+    public void setEnv(String env) {
+        this.env = env;
+    }
+
+    public void setIdc(String idc) {
+        this.idc = idc;
+    }
+
+    public void setConsumerGroup(String consumerGroup) {
+        this.consumerGroup = consumerGroup;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public void setSys(String sys) {
+        this.sys = sys;
+    }
+
+    public void setIp(String ip) {
+        this.ip = ip;
+    }
+
+    public void setPid(String pid) {
+        this.pid = pid;
+    }
+
+    public void setHostname(String hostname) {
+        this.hostname = hostname;
+    }
+
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    public void setLastUpTime(Date lastUpTime) {
+        this.lastUpTime = lastUpTime;
+    }
+
+    private String apiVersion;
+
+    public String getEnv() {
+        return env;
+    }
+
+    public String getIdc() {
+        return idc;
+    }
+
+    public String getConsumerGroup() {
+        return consumerGroup;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getSys() {
+        return sys;
+    }
+
+    public String getIp() {
+        return ip;
+    }
+
+    public String getPid() {
+        return pid;
+    }
+
+    public String getHostname() {
+        return hostname;
+    }
+
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    public Date getLastUpTime() {
+        return lastUpTime;
+    }
+
 
     @Override
     public String toString() {


### PR DESCRIPTION

Fixes #2729 .

### Motivation

Method check a map with containsKey(), before using get() [UnSubscribeProcessor]


### Modifications

refactor eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/UnSubscribeProcessor.java ,
fetch the value with get, and checking for non null instead.

### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? ( not documented)
