### PR TITLE
[ISSUE #2656] Method uses immediate execution of a block of code that is often not used [LocalUnSubscribeEventProcessor]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalUnSubscribeEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalUnSubscribeEventProcessor.java
@@ -208,10 +208,9 @@ public class LocalUnSubscribeEventProcessor extends AbstractEventProcessor {
 
                 } catch (Exception e) {
                     if (LOGGER.isErrorEnabled()) {
-                        LOGGER.error(
-                                String.format("message|eventMesh2mq|REQ|ASYNC|send2MQCost=%sms"
-                                                + "|topic=%s|url=%s", System.currentTimeMillis() - startTime,
-                                        JsonUtils.serialize(unSubTopicList), unSubscribeUrl), e);
+                        LOGGER.error("message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms"
+                                        + "|topic={}|url={}", System.currentTimeMillis() - startTime,
+                                JsonUtils.serialize(unSubTopicList), unSubscribeUrl, e);
                     }
                     handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_UNSUBSCRIBE_ERR, responseHeaderMap,
                             responseBodyMap, null);
@@ -233,10 +232,9 @@ public class LocalUnSubscribeEventProcessor extends AbstractEventProcessor {
                             .removeIf(s -> StringUtils.equals(consumerGroup, s));
                 } catch (Exception e) {
                     if (LOGGER.isErrorEnabled()) {
-                        LOGGER.error(
-                                String.format("message|eventMesh2mq|REQ|ASYNC|send2MQCost=%sms"
-                                                + "|topic=%s|url=%s", System.currentTimeMillis() - startTime,
-                                        JsonUtils.serialize(unSubTopicList), unSubscribeUrl), e);
+                        LOGGER.error("message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms"
+                                                + "|topic={}|url={}", System.currentTimeMillis() - startTime,
+                                        JsonUtils.serialize(unSubTopicList), unSubscribeUrl, e);
                     }
                     handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_UNSUBSCRIBE_ERR, responseHeaderMap,
                             responseBodyMap, null);


### PR DESCRIPTION

Fixes #2656 .

### Motivation

Method uses immediate execution of a block of code that is often not used [LocalUnSubscribeEventProcessor]

### Modifications

 replace Optional.orElse() with Optional.orElseGet().


### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
