### PR TITLE
[ISSUE #2726] Method check a map with containsKey(), before using get() [LocalSubscribeEventProcessor]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalSubscribeEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalSubscribeEventProcessor.java
@@ -158,7 +158,7 @@ public class LocalSubscribeEventProcessor extends AbstractEventProcessor {
             }
         } catch (Exception e) {
             if (LOGGER.isErrorEnabled()) {
-                LOGGER.error(String.format("subscriber url {} is not valid", url), e);
+                LOGGER.error("subscriber url {} is not valid", url, e);
             }
 
             handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR, responseHeaderMap,
@@ -265,10 +265,10 @@ public class LocalSubscribeEventProcessor extends AbstractEventProcessor {
 
             } catch (Exception e) {
                 if (LOGGER.isErrorEnabled()) {
-                    LOGGER.error(String.format("message|eventMesh2mq|REQ|ASYNC|send2MQCost=%sms|topic=%s|url=%s",
+                    LOGGER.error("message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}|url={}",
                             System.currentTimeMillis() - startTime,
                             JsonUtils.serialize(subscriptionList),
-                            url), e);
+                            url, e);
                 }
 
                 handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_SUBSCRIBE_ERR, responseHeaderMap,


### PR DESCRIPTION


Fixes #2726 .

### Motivation

Method check a map with containsKey(), before using get() [LocalSubscribeEventProcessor]


### Modifications


refactor eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalSubscribeEventProcessor.java ,
It is much simpler to just fetch the value with get, and checking for non null instead.


### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
