### PR TITLE
[ISSUE #2676] fix call the same method on the BatchSendMessageV2Processor redundantly

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/http/header/message/SendMessageBatchV2ResponseHeader.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/http/header/message/SendMessageBatchV2ResponseHeader.java
@@ -19,6 +19,7 @@ package org.apache.eventmesh.common.protocol.http.header.message;
 
 import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.protocol.http.header.Header;
+import org.apache.eventmesh.common.utils.IPUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -81,14 +82,13 @@ public class SendMessageBatchV2ResponseHeader extends Header {
     }
 
     public static SendMessageBatchV2ResponseHeader buildHeader(Integer requestCode, String eventMeshCluster,
-                                                               String eventMeshIp, String eventMeshEnv,
-                                                               String eventMeshIDC) {
+                                                               String eventMeshEnv, String eventMeshIDC) {
         SendMessageBatchV2ResponseHeader header = new SendMessageBatchV2ResponseHeader();
         header.setCode(requestCode);
         header.setEventMeshCluster(eventMeshCluster);
         header.setEventMeshEnv(eventMeshEnv);
         header.setEventMeshIdc(eventMeshIDC);
-        header.setEventMeshIp(eventMeshIp);
+        header.setEventMeshIp(IPUtils.getLocalAddress());
         return header;
     }
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/BatchSendMessageV2Processor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/BatchSendMessageV2Processor.java
@@ -31,7 +31,6 @@ import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.protocol.http.common.RequestCode;
 import org.apache.eventmesh.common.protocol.http.header.message.SendMessageBatchV2RequestHeader;
 import org.apache.eventmesh.common.protocol.http.header.message.SendMessageBatchV2ResponseHeader;
-import org.apache.eventmesh.common.utils.IPUtils;
 import org.apache.eventmesh.protocol.api.ProtocolAdaptor;
 import org.apache.eventmesh.protocol.api.ProtocolPluginFactory;
 import org.apache.eventmesh.runtime.acl.Acl;
@@ -82,7 +81,8 @@ public class BatchSendMessageV2Processor implements HttpRequestProcessor {
         cmdLogger.info("cmd={}|{}|client2eventMesh|from={}|to={}",
             RequestCode.get(requestCode),
             EventMeshConstants.PROTOCOL_HTTP,
-            RemotingHelper.parseChannelRemoteAddr(ctx.channel()), IPUtils.getLocalAddress());
+            RemotingHelper.parseChannelRemoteAddr(ctx.channel()),
+            RemotingHelper.parseChannelRemoteAddr(ctx.channel()));
 
         SendMessageBatchV2RequestHeader sendMessageBatchV2RequestHeader =
             (SendMessageBatchV2RequestHeader) asyncContext.getRequest().getHeader();
@@ -96,7 +96,6 @@ public class BatchSendMessageV2Processor implements HttpRequestProcessor {
             SendMessageBatchV2ResponseHeader.buildHeader(
                 requestCode,
                     eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshCluster(),
-                IPUtils.getLocalAddress(),
                     eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshEnv(),
                     eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshIDC()
             );

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/RemotingHelper.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/RemotingHelper.java
@@ -69,6 +69,25 @@ public abstract class RemotingHelper {
         return "";
     }
 
+    public static String parseChannelLocalAddr(final Channel channel) {
+        if (null == channel) {
+            return "";
+        }
+
+        final String addr = channel.localAddress() != null ? channel.localAddress().toString() : "";
+
+        if (addr.length() > 0) {
+            final int index = addr.lastIndexOf('/');
+            if (index >= 0) {
+                return addr.substring(index + 1);
+            }
+
+            return addr;
+        }
+
+        return "";
+    }
+
     public static String parseSocketAddressAddr(final InetSocketAddress socketAddress) {
         return socketAddress != null ? socketAddress.getAddress().getHostAddress() + ":" + socketAddress.getPort() : "";
     }


### PR DESCRIPTION
Fixes #2676 .

### Motivation
To avoid calling the same method on the same object redundantly.


### Modifications

* add  `parseChannelLocalAddr` in RemotingHelper to get local address from channel.
* assign `eventMeshIp` in `buildHeader` by using IPUtil instead of passing the value to it.


