### PR TITLE
[ISSUE #2671] Method appears to call the same method on the same object redundantly [SendAsyncEventProcessor]

### DIFF
--- a/eventmesh-metrics-plugin/eventmesh-metrics-api/src/main/java/org/apache/eventmesh/metrics/api/model/TcpSummaryMetrics.java
+++ b/eventmesh-metrics-plugin/eventmesh-metrics-api/src/main/java/org/apache/eventmesh/metrics/api/model/TcpSummaryMetrics.java
@@ -28,10 +28,10 @@ public class TcpSummaryMetrics implements Metric {
     private AtomicInteger mq2eventMeshMsgNum;
     private AtomicInteger eventMesh2clientMsgNum;
 
-    private double client2eventMeshTPS;
-    private double eventMesh2clientTPS;
-    private double eventMesh2mqTPS;
-    private double mq2eventMeshTPS;
+    private int client2eventMeshTPS;
+    private int eventMesh2clientTPS;
+    private int eventMesh2mqTPS;
+    private int mq2eventMeshTPS;
     private int subTopicNum;
 
     private int allConnections;
@@ -77,39 +77,39 @@ public class TcpSummaryMetrics implements Metric {
         this.eventMesh2clientMsgNum = new AtomicInteger(0);
     }
 
-    public double getClient2eventMeshTPS() {
+    public int getClient2eventMeshTPS() {
         return client2eventMeshTPS;
     }
 
-    public void setClient2eventMeshTPS(double client2eventMeshTPS) {
+    public void setClient2eventMeshTPS(int client2eventMeshTPS) {
         this.client2eventMeshTPS = client2eventMeshTPS;
     }
 
-    public double getEventMesh2clientTPS() {
+    public int getEventMesh2clientTPS() {
         return eventMesh2clientTPS;
     }
 
-    public void setEventMesh2clientTPS(double eventMesh2clientTPS) {
+    public void setEventMesh2clientTPS(int eventMesh2clientTPS) {
         this.eventMesh2clientTPS = eventMesh2clientTPS;
     }
 
-    public double getEventMesh2mqTPS() {
+    public int getEventMesh2mqTPS() {
         return eventMesh2mqTPS;
     }
 
-    public void setEventMesh2mqTPS(double eventMesh2mqTPS) {
+    public void setEventMesh2mqTPS(int eventMesh2mqTPS) {
         this.eventMesh2mqTPS = eventMesh2mqTPS;
     }
 
-    public double getMq2eventMeshTPS() {
+    public int getMq2eventMeshTPS() {
         return mq2eventMeshTPS;
     }
 
-    public void setMq2eventMeshTPS(double mq2eventMeshTPS) {
+    public void setMq2eventMeshTPS(int mq2eventMeshTPS) {
         this.mq2eventMeshTPS = mq2eventMeshTPS;
     }
 
-    public double getAllTPS() {
+    public int getAllTPS() {
         return client2eventMeshTPS + eventMesh2clientTPS;
     }
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/ConfigurationHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/ConfigurationHandler.java
@@ -46,9 +46,9 @@ public class ConfigurationHandler implements HttpHandler {
     private final EventMeshGrpcConfiguration eventMeshGrpcConfiguration;
 
     public ConfigurationHandler(
-        EventMeshTCPConfiguration eventMeshTCPConfiguration,
-        EventMeshHTTPConfiguration eventMeshHTTPConfiguration,
-        EventMeshGrpcConfiguration eventMeshGrpcConfiguration
+            EventMeshTCPConfiguration eventMeshTCPConfiguration,
+            EventMeshHTTPConfiguration eventMeshHTTPConfiguration,
+            EventMeshGrpcConfiguration eventMeshGrpcConfiguration
     ) {
         this.eventMeshTCPConfiguration = eventMeshTCPConfiguration;
         this.eventMeshHTTPConfiguration = eventMeshHTTPConfiguration;
@@ -89,18 +89,14 @@ public class ConfigurationHandler implements HttpHandler {
                     eventMeshTCPConfiguration.getEventMeshWebhookOrigin(),
                     eventMeshTCPConfiguration.isEventMeshServerSecurityEnable(),
                     eventMeshTCPConfiguration.isEventMeshServerRegistryEnable(),
-
-                // TCP Configuration
-                eventMeshTCPConfiguration.eventMeshTcpServerPort,
-                eventMeshTCPConfiguration.eventMeshTcpSendBackEnabled,
-
-                // HTTP Configuration
-                eventMeshHTTPConfiguration.httpServerPort,
-                eventMeshHTTPConfiguration.eventMeshServerUseTls,
-
-                // gRPC Configuration
-                eventMeshGrpcConfiguration.grpcServerPort,
-                eventMeshGrpcConfiguration.eventMeshServerUseTls
+                    // TCP Configuration
+                    eventMeshTCPConfiguration.eventMeshTcpServerPort,
+                    // HTTP Configuration
+                    eventMeshHTTPConfiguration.httpServerPort,
+                    eventMeshHTTPConfiguration.eventMeshServerUseTls,
+                    // gRPC Configuration
+                    eventMeshGrpcConfiguration.grpcServerPort,
+                    eventMeshGrpcConfiguration.eventMeshServerUseTls
             );
 
             String result = JsonUtils.toJson(getConfigurationResponse);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/ConfigurationHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/ConfigurationHandler.java
@@ -79,20 +79,20 @@ public class ConfigurationHandler implements HttpHandler {
 
         try {
             GetConfigurationResponse getConfigurationResponse = new GetConfigurationResponse(
-                eventMeshTCPConfiguration.sysID,
-                eventMeshTCPConfiguration.namesrvAddr,
-                eventMeshTCPConfiguration.eventMeshEnv,
-                eventMeshTCPConfiguration.eventMeshIDC,
-                eventMeshTCPConfiguration.eventMeshCluster,
-                eventMeshTCPConfiguration.eventMeshServerIp,
-                eventMeshTCPConfiguration.eventMeshName,
-                eventMeshTCPConfiguration.eventMeshWebhookOrigin,
-                eventMeshTCPConfiguration.eventMeshServerSecurityEnable,
-                eventMeshTCPConfiguration.eventMeshServerRegistryEnable,
+                    eventMeshTCPConfiguration.getSysID(),
+                    eventMeshTCPConfiguration.getNamesrvAddr(),
+                    eventMeshTCPConfiguration.getEventMeshEnv(),
+                    eventMeshTCPConfiguration.getEventMeshIDC(),
+                    eventMeshTCPConfiguration.getEventMeshCluster(),
+                    eventMeshTCPConfiguration.getEventMeshServerIp(),
+                    eventMeshTCPConfiguration.getEventMeshName(),
+                    eventMeshTCPConfiguration.getEventMeshWebhookOrigin(),
+                    eventMeshTCPConfiguration.isEventMeshServerSecurityEnable(),
+                    eventMeshTCPConfiguration.isEventMeshServerRegistryEnable(),
 
                 // TCP Configuration
                 eventMeshTCPConfiguration.eventMeshTcpServerPort,
-                eventMeshTCPConfiguration.eventMeshTcpServerEnabled,
+                eventMeshTCPConfiguration.eventMeshTcpSendBackEnabled,
 
                 // HTTP Configuration
                 eventMeshHTTPConfiguration.httpServerPort,

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/HTTPClientHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/HTTPClientHandler.java
@@ -49,7 +49,7 @@ public class HTTPClientHandler implements HttpHandler {
     private final EventMeshHTTPServer eventMeshHTTPServer;
 
     public HTTPClientHandler(
-        EventMeshHTTPServer eventMeshHTTPServer
+            EventMeshHTTPServer eventMeshHTTPServer
     ) {
         this.eventMeshHTTPServer = eventMeshHTTPServer;
     }
@@ -78,7 +78,7 @@ public class HTTPClientHandler implements HttpHandler {
             String url = deleteHTTPClientRequest.url;
 
             for (List<Client> clientList : eventMeshHTTPServer.localClientInfoMapping.values()) {
-                clientList.removeIf(client -> Objects.equals(client.url, url));
+                clientList.removeIf(client -> Objects.equals(client.getUrl(), url));
             }
 
             httpExchange.getResponseHeaders().add("Access-Control-Allow-Origin", "*");
@@ -121,17 +121,17 @@ public class HTTPClientHandler implements HttpHandler {
             for (List<Client> clientList : eventMeshHTTPServer.localClientInfoMapping.values()) {
                 for (Client client : clientList) {
                     GetClientResponse getClientResponse = new GetClientResponse(
-                        Optional.ofNullable(client.env).orElse(""),
-                        Optional.ofNullable(client.sys).orElse(""),
-                        Optional.ofNullable(client.url).orElse(""),
-                        "0",
-                        Optional.ofNullable(client.hostname).orElse(""),
-                        0,
-                        Optional.ofNullable(client.apiVersion).orElse(""),
-                        Optional.ofNullable(client.idc).orElse(""),
-                        Optional.ofNullable(client.consumerGroup).orElse(""),
-                        "",
-                        "HTTP"
+                            Optional.ofNullable(client.getEnv()).orElseGet(() -> ""),
+                            Optional.ofNullable(client.getSys()).orElseGet(() -> ""),
+                            Optional.ofNullable(client.getUrl()).orElseGet(() -> ""),
+                            "0",
+                            Optional.ofNullable(client.getHostname()).orElseGet(() -> ""),
+                            0,
+                            Optional.ofNullable(client.getApiVersion()).orElseGet(() -> ""),
+                            Optional.ofNullable(client.getIdc()).orElseGet(() -> ""),
+                            Optional.ofNullable(client.getConsumerGroup()).orElseGet(() -> ""),
+                            "",
+                            "HTTP"
                     );
                     getClientResponseList.add(getClientResponse);
                 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/MetricsHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/MetricsHandler.java
@@ -43,7 +43,7 @@ public class MetricsHandler implements HttpHandler {
     private final TcpSummaryMetrics tcpSummaryMetrics;
 
     public MetricsHandler(EventMeshHTTPServer eventMeshHTTPServer, EventMeshTCPServer eventMeshTcpServer) {
-        this.httpSummaryMetrics = eventMeshHTTPServer.metrics.getSummaryMetrics();
+        this.httpSummaryMetrics = eventMeshHTTPServer.getMetrics().getSummaryMetrics();
         this.tcpSummaryMetrics = eventMeshTcpServer.getEventMeshTcpMonitor().getTcpSummaryMetrics();
     }
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/AbstractHTTPServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/AbstractHTTPServer.java
@@ -139,10 +139,10 @@ public abstract class AbstractHTTPServer extends AbstractRemotingServer {
 
 
     protected final transient Map<String/* request code */, Pair<HttpRequestProcessor, ThreadPoolExecutor>>
-            processorTable = new ConcurrentHashMap(64);
+            processorTable = new ConcurrentHashMap<>(64);
 
     protected final transient Map<String/* request uri */, Pair<EventProcessor, ThreadPoolExecutor>>
-            eventProcessorTable = new ConcurrentHashMap(64);
+            eventProcessorTable = new ConcurrentHashMap<>(64);
 
     public AbstractHTTPServer(final int port, final boolean useTLS,
                               final EventMeshHTTPConfiguration eventMeshHttpConfiguration) {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/configuration/EventMeshTCPConfiguration.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/configuration/EventMeshTCPConfiguration.java
@@ -62,6 +62,7 @@ public class EventMeshTCPConfiguration extends CommonConfiguration {
 
     public int eventMeshServerAdminPort = 10106;
 
+
     public boolean eventMeshTcpSendBackEnabled = Boolean.TRUE;
 
     public int eventMeshTcpSendBackMaxTimes = 3;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/metrics/tcp/EventMeshTcpMonitor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/metrics/tcp/EventMeshTcpMonitor.java
@@ -88,23 +88,23 @@ public class EventMeshTcpMonitor {
         monitorTpsTask = eventMeshTCPServer.getScheduler().scheduleAtFixedRate((() -> {
             int msgNum = tcpSummaryMetrics.client2eventMeshMsgNum();
             tcpSummaryMetrics.resetClient2EventMeshMsgNum();
-            tcpSummaryMetrics.setClient2eventMeshTPS(1000.0d * msgNum / period);
+            tcpSummaryMetrics.setClient2eventMeshTPS((int) 1000.0d * msgNum / period);
 
             msgNum = tcpSummaryMetrics.eventMesh2clientMsgNum();
             tcpSummaryMetrics.resetEventMesh2ClientMsgNum();
-            tcpSummaryMetrics.setEventMesh2clientTPS(1000.0d * msgNum / period);
+            tcpSummaryMetrics.setEventMesh2clientTPS((int) 1000.0d * msgNum / period);
 
             msgNum = tcpSummaryMetrics.eventMesh2mqMsgNum();
             tcpSummaryMetrics.resetEventMesh2mqMsgNum();
-            tcpSummaryMetrics.setEventMesh2mqTPS(1000.0d * msgNum / period);
+            tcpSummaryMetrics.setEventMesh2mqTPS((int) 1000.0d * msgNum / period);
 
             msgNum = tcpSummaryMetrics.mq2eventMeshMsgNum();
             tcpSummaryMetrics.resetMq2eventMeshMsgNum();
-            tcpSummaryMetrics.setMq2eventMeshTPS(1000.0d * msgNum / period);
+            tcpSummaryMetrics.setMq2eventMeshTPS((int) 1000.0d * msgNum / period);
 
             //count topics subscribed by client in this eventMesh
             ConcurrentHashMap<InetSocketAddress, Session> sessionMap =
-                eventMeshTCPServer.getClientSessionGroupMapping().getSessionMap();
+                    eventMeshTCPServer.getClientSessionGroupMapping().getSessionMap();
             Iterator<Session> sessionIterator = sessionMap.values().iterator();
             Set<String> topicSet = new HashSet<>();
             while (sessionIterator.hasNext()) {
@@ -116,8 +116,8 @@ public class EventMeshTcpMonitor {
                 int subscribeTopics = session.getSessionContext().subscribeTopics.size();
 
                 tcpLogger.info("session|deliveredFailCount={}|deliveredMsgsCount={}|unAckMsgsCount={}|sendTopics={}|subscribeTopics={}|user={}",
-                    deliveredFailCount.longValue(), deliveredMsgsCount.longValue(),
-                    unAckMsgsCount, sendTopics, subscribeTopics, session.getClient());
+                        deliveredFailCount.longValue(), deliveredMsgsCount.longValue(),
+                        unAckMsgsCount, sendTopics, subscribeTopics, session.getClient());
 
                 topicSet.addAll(session.getSessionContext().subscribeTopics.keySet());
             }
@@ -135,10 +135,10 @@ public class EventMeshTcpMonitor {
             //monitor retry queue size
             tcpSummaryMetrics.setRetrySize(eventMeshTCPServer.getEventMeshTcpRetryer().getRetrySize());
             appLogger.info(String.format(
-                MonitorMetricConstants.EVENTMESH_MONITOR_FORMAT_COMMON,
-                EventMeshConstants.PROTOCOL_TCP,
-                MonitorMetricConstants.RETRY_QUEUE_SIZE,
-                tcpSummaryMetrics.getRetrySize()));
+                    MonitorMetricConstants.EVENTMESH_MONITOR_FORMAT_COMMON,
+                    EventMeshConstants.PROTOCOL_TCP,
+                    MonitorMetricConstants.RETRY_QUEUE_SIZE,
+                    tcpSummaryMetrics.getRetrySize()));
 
         }, 10, PRINT_THREADPOOLSTATE_INTERVAL, TimeUnit.SECONDS);
         log.info("EventMeshTcpMonitor started......");
@@ -146,25 +146,25 @@ public class EventMeshTcpMonitor {
 
     private void printAppLogger(TcpSummaryMetrics tcpSummaryMetrics) {
         appLogger.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.CLIENT_2_EVENTMESH_TPS,
-            tcpSummaryMetrics.getClient2eventMeshTPS());
+                tcpSummaryMetrics.getClient2eventMeshTPS());
 
         appLogger.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.EVENTMESH_2_MQ_TPS,
-            tcpSummaryMetrics.getEventMesh2mqTPS());
+                tcpSummaryMetrics.getEventMesh2mqTPS());
 
         appLogger.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.MQ_2_EVENTMESH_TPS,
-            tcpSummaryMetrics.getMq2eventMeshTPS());
+                tcpSummaryMetrics.getMq2eventMeshTPS());
 
         appLogger.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.EVENTMESH_2_CLIENT_TPS,
-            tcpSummaryMetrics.getEventMesh2clientTPS());
+                tcpSummaryMetrics.getEventMesh2clientTPS());
 
         appLogger.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.ALL_TPS,
-            tcpSummaryMetrics.getAllTPS());
+                tcpSummaryMetrics.getAllTPS());
 
         appLogger.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.CONNECTION,
-            tcpSummaryMetrics.getAllConnections());
+                tcpSummaryMetrics.getAllConnections());
 
         appLogger.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.SUB_TOPIC_NUM,
-            tcpSummaryMetrics.getSubTopicNum());
+                tcpSummaryMetrics.getSubTopicNum());
     }
 
     public TcpSummaryMetrics getTcpSummaryMetrics() {


### PR DESCRIPTION

Fixes #2671  

### Motivation

Method appears to call the same method on the same object redundantly [SendAsyncEventProcessor]


### Modifications

These method calls could be combined by assigning the result into a temporary variable, and using the variable the second time.


### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
