### PR TITLE
[ISSUE #2822] Use retainAll method instead of iterating over keys in Map [EventMeshRecommendImpl]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/recommend/EventMeshRecommendImpl.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/recommend/EventMeshRecommendImpl.java
@@ -230,7 +230,7 @@ public class EventMeshRecommendImpl implements EventMeshRecommendStrategy {
 
         Set<String> clientdDistributionSet=new HashSet<>(clientDistributionMap.keySet());
         clientdDistributionSet.retainAll(eventMeshMap.keySet());
-        if(!clientdDistributionSet.isEmpty()){
+        if(clientdDistributionSet.isEmpty()){
             if (log.isWarnEnabled()) {
                 log.warn("exist proxy not register but exist in distributionMap");
             }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/recommend/EventMeshRecommendImpl.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/recommend/EventMeshRecommendImpl.java
@@ -25,7 +25,14 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.HashSet;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/recommend/EventMeshRecommendImpl.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/recommend/EventMeshRecommendImpl.java
@@ -25,12 +25,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -226,15 +221,16 @@ public class EventMeshRecommendImpl implements EventMeshRecommendStrategy {
             log.info("eventMeshMap:{},clientDistributionMap:{},group:{}", eventMeshMap, clientDistributionMap, group);
         }
 
-        if (!eventMeshMap.keySet().containsAll(clientDistributionMap.keySet())) {
+        Set<String> clientdDistributionSet=new HashSet<>(clientDistributionMap.keySet());
+        clientdDistributionSet.retainAll(eventMeshMap.keySet());
+        if(!clientdDistributionSet.isEmpty()){
             if (log.isWarnEnabled()) {
                 log.warn("exist proxy not register but exist in distributionMap");
             }
             return null;
         }
 
-
-        eventMeshMap.keySet().forEach(proxy -> clientDistributionMap.putIfAbsent(proxy, 0));
+        eventMeshMap.keySet().parallelStream().forEach(proxy -> clientDistributionMap.putIfAbsent(proxy, 0));
 
         //select the eventmesh with least instances
         if (MapUtils.isEmpty(clientDistributionMap)) {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/recommend/EventMeshRecommendImpl.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/recommend/EventMeshRecommendImpl.java
@@ -229,8 +229,8 @@ public class EventMeshRecommendImpl implements EventMeshRecommendStrategy {
         }
 
         Set<String> clientdDistributionSet=new HashSet<>(clientDistributionMap.keySet());
-        clientdDistributionSet.retainAll(eventMeshMap.keySet());
-        if(clientdDistributionSet.isEmpty()){
+        clientdDistributionSet.removeAll(eventMeshMap.keySet());
+        if(!clientdDistributionSet.isEmpty()){
             if (log.isWarnEnabled()) {
                 log.warn("exist proxy not register but exist in distributionMap");
             }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/recommend/EventMeshRecommendImpl.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/recommend/EventMeshRecommendImpl.java
@@ -228,9 +228,9 @@ public class EventMeshRecommendImpl implements EventMeshRecommendStrategy {
             log.info("eventMeshMap:{},clientDistributionMap:{},group:{}", eventMeshMap, clientDistributionMap, group);
         }
 
-        Set<String> clientdDistributionSet=new HashSet<>(clientDistributionMap.keySet());
+        Set<String> clientdDistributionSet = new HashSet<>(clientDistributionMap.keySet());
         clientdDistributionSet.removeAll(eventMeshMap.keySet());
-        if(!clientdDistributionSet.isEmpty()){
+        if (!clientdDistributionSet.isEmpty()) {
             if (log.isWarnEnabled()) {
                 log.warn("exist proxy not register but exist in distributionMap");
             }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Cloese #<XXX>`.)
-->

Fixes #2822 .

### Motivation

*Iteration over keyset can be avoided or use of containsAll could be avoided*



### Modifications

*Using the retainAll method to get the intersection of sets from the keySet method of the Map interface to get the set of keys for both map1 and map2 can avoid iteration over entire keySet.*



### Documentation

- Does this pull request introduce a new feature? ( no)
