### PR TITLE
[ISSUE #2849] org.apache.eventmesh.runtime.util.WebhookUtilTest > testObtainDeliveryAgreement FAILED

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/WebhookUtil.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/WebhookUtil.java
@@ -32,17 +32,15 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Utility class for implementing CloudEvents Http Webhook spec
  *
  * @see <a href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/http-webhook.md">CloudEvents Http Webhook</a>
  */
+@Slf4j
 public class WebhookUtil {
-    private static final Logger LOGGER = LoggerFactory.getLogger(WebhookUtil.class);
-
     private static final String CONTENT_TYPE_HEADER = "Content-Type";
     private static final String REQUEST_ORIGIN_HEADER = "WebHook-Request-Origin";
     private static final String ALLOWED_ORIGIN_HEADER = "WebHook-Allowed-Origin";
@@ -53,8 +51,8 @@ public class WebhookUtil {
                                                   final String targetUrl,
                                                   final String requestOrigin) {
         
-        if (LOGGER.isInfoEnabled()) {
-            LOGGER.info("obtain webhook delivery agreement for url: {}", targetUrl);
+        if (log.isInfoEnabled()) {
+            log.info("obtain webhook delivery agreement for url: {}", targetUrl);
         }
 
         final HttpOptions builder = new HttpOptions(targetUrl);
@@ -65,8 +63,10 @@ public class WebhookUtil {
             return StringUtils.isEmpty(allowedOrigin)
                     || "*".equals(allowedOrigin) || allowedOrigin.equalsIgnoreCase(requestOrigin);
         } catch (Exception e) {
-            LOGGER.error("HTTP Options Method is not supported at the Delivery Target: {}, "
-                + "unable to obtain the webhook delivery agreement.", targetUrl);
+            if (log.isErrorEnabled()) {
+                log.error("HTTP Options Method is not supported at the Delivery Target: {}, "
+                        + "unable to obtain the webhook delivery agreement.", targetUrl);
+            }
         }
         return true;
     }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/WebhookUtilTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/WebhookUtilTest.java
@@ -25,13 +25,11 @@ import static org.mockito.Mockito.mock;
 import org.apache.eventmesh.api.auth.AuthService;
 import org.apache.eventmesh.spi.EventMeshExtensionFactory;
 
-import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicHeader;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -45,21 +43,23 @@ public class WebhookUtilTest {
     @Test
     public void testObtainDeliveryAgreement() {
         // normal case
-        try (CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
-             CloseableHttpResponse response = Mockito.mock(CloseableHttpResponse.class);
-             CloseableHttpClient httpClient2 = Mockito.mock(CloseableHttpClient.class)) {
+        try (CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+             CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+             CloseableHttpClient httpClient2 = mock(CloseableHttpClient.class)) {
 
-            Mockito.when(response.getLastHeader("WebHook-Allowed-Origin")).thenReturn(new BasicHeader("WebHook-Allowed-Origin", "*"));
+            Mockito.when(response.getLastHeader("WebHook-Allowed-Origin")).
+                    thenReturn(new BasicHeader("WebHook-Allowed-Origin", "*"));
             Mockito.when(httpClient.execute(any())).thenReturn(response);
-            Assert.assertTrue(WebhookUtil.obtainDeliveryAgreement(httpClient, "https://eventmesh.apache.org", "*"));
+            Assert.assertTrue("match logic must return true",
+                    WebhookUtil.obtainDeliveryAgreement(httpClient, "https://eventmesh.apache.org", "*"));
 
             // abnormal case
             Mockito.when(httpClient2.execute(any())).thenThrow(new RuntimeException());
             try {
-                WebhookUtil.obtainDeliveryAgreement(httpClient2, "xxx", "*");
-                Assert.fail("invalid url should throw RuntimeException!");
+                Assert.assertTrue("when throw exception ,default return true",
+                        WebhookUtil.obtainDeliveryAgreement(httpClient2, "xxx", "*"));
             } catch (RuntimeException e) {
-                Assert.assertNotNull(e);
+                Assert.fail(e.getMessage());
             }
 
         } catch (Exception e) {
@@ -69,20 +69,20 @@ public class WebhookUtilTest {
 
     @Test
     public void testSetWebhookHeaders() {
-        String authType = "auth-http-basic";
-        AuthService authService = mock(AuthService.class);
+        final String authType = "auth-http-basic";
+        final AuthService authService = mock(AuthService.class);
         doNothing().when(authService).init();
-        Map<String, String> authParams = new HashMap<>();
-        String key = "Authorization";
-        String value = "Basic ****";
+        final Map<String, String> authParams = new HashMap<>();
+        final String key = "Authorization";
+        final String value = "Basic ****";
         authParams.put(key, value);
         Mockito.when(authService.getAuthParams()).thenReturn(authParams);
 
         try (MockedStatic<EventMeshExtensionFactory> dummyStatic = Mockito.mockStatic(EventMeshExtensionFactory.class)) {
             dummyStatic.when(() -> EventMeshExtensionFactory.getExtension(AuthService.class, authType)).thenReturn(authService);
-            HttpPost post = new HttpPost();
+            final HttpPost post = new HttpPost();
             WebhookUtil.setWebhookHeaders(post, "application/json", "eventmesh.FT", authType);
-            Assert.assertEquals(post.getLastHeader(key).getValue(), value);
+            Assert.assertEquals("match expect value", post.getLastHeader(key).getValue(), value);
         }
     }
 }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/WebhookUtilTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/WebhookUtilTest.java
@@ -47,8 +47,8 @@ public class WebhookUtilTest {
              CloseableHttpResponse response = mock(CloseableHttpResponse.class);
              CloseableHttpClient httpClient2 = mock(CloseableHttpClient.class)) {
 
-            Mockito.when(response.getLastHeader("WebHook-Allowed-Origin")).
-                    thenReturn(new BasicHeader("WebHook-Allowed-Origin", "*"));
+            Mockito.when(response.getLastHeader("WebHook-Allowed-Origin"))
+                    .thenReturn(new BasicHeader("WebHook-Allowed-Origin", "*"));
             Mockito.when(httpClient.execute(any())).thenReturn(response);
             Assert.assertTrue("match logic must return true",
                     WebhookUtil.obtainDeliveryAgreement(httpClient, "https://eventmesh.apache.org", "*"));


### PR DESCRIPTION


Fixes #2849 .

### Motivation

fix bug:
org.apache.eventmesh.runtime.util.WebhookUtilTest > testObtainDeliveryAgreement FAILED


### Modifications

modify assertion



### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
