### PR TITLE
[ISSUE #2863] eventmesh-server-go module add golangci-lint command in Makefile 

### DIFF
--- a/eventmesh-sdk-go/README.md
+++ b/eventmesh-sdk-go/README.md
@@ -6,7 +6,7 @@ EventMesh Go SDK
 
 - Makefile tip
  >1. use golangci-lint static code check
- >>- install: `go get github.com/golangci/golangci-lint/cmd/golangci-lint@latest`
+ >>- install: `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest`
  >>- `make lint`
  
  >2. test code

--- a/eventmesh-server-go/Makefile
+++ b/eventmesh-server-go/Makefile
@@ -15,13 +15,95 @@
 # limitations under the License.
 #
 
-.PHONY: build
-build:
-	mkdir -p bin/ && go build -o ./bin 
+################################################################################
+# Variables                                                                    #
+################################################################################
+export GO111MODULE ?= on
+export GOPROXY ?= https://proxy.golang.org
+export GOSUMDB ?= sum.golang.org
 
+# By default, disable CGO_ENABLED. See the details on https://golang.org/cmd/cgo
+CGO         ?= 0
+
+LOCAL_ARCH := $(shell uname -m)
+ifeq ($(LOCAL_ARCH),x86_64)
+	TARGET_ARCH_LOCAL=amd64
+else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 5),armv8)
+	TARGET_ARCH_LOCAL=arm64
+else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 4),armv)
+	TARGET_ARCH_LOCAL=arm
+else
+	TARGET_ARCH_LOCAL=amd64
+endif
+export GOARCH ?= $(TARGET_ARCH_LOCAL)
+
+LOCAL_OS := $(shell uname)
+ifeq ($(LOCAL_OS),Linux)
+   TARGET_OS_LOCAL = linux
+else ifeq ($(LOCAL_OS),Darwin)
+   TARGET_OS_LOCAL = darwin
+else
+   TARGET_OS_LOCAL ?= windows
+endif
+export GOOS ?= $(TARGET_OS_LOCAL)
+
+ifeq ($(GOOS),windows)
+BINARY_EXT_LOCAL:=.exe
+GOLANGCI_LINT:=golangci-lint.exe
+BUILDMODE:=-buildmode=exe
+else
+BINARY_EXT_LOCAL:=
+GOLANGCI_LINT:=golangci-lint
+endif
+
+COVERAGE_OPTS = -covermode=set -coverprofile=cover_set.out
+
+
+################################################################################
+# Target: test                                                                 #
+################################################################################
 .PHONY: test
 test:
 	go test ./...
 
+################################################################################
+# Target: build                                                                 #
+################################################################################
+.PHONY: build
+build:
+	mkdir -p bin/ && go build -o ./bin
+
+################################################################################
+# Target: coverage                                                                 #
+################################################################################
+.PHONY: coverage
 coverage:
-	 go test -covermode=set ./...
+	go test ./... $(COVERAGE_OPTS)
+
+################################################################################
+# Target: lint                                                                 #
+################################################################################
+.PHONY: lint
+lint:
+	$(GOLANGCI_LINT) run --timeout=20m
+
+################################################################################
+# Target: go.mod                                                               #
+################################################################################
+.PHONY: go.mod
+go.mod:
+	go mod tidy
+
+################################################################################
+# Target: check-diff                                                           #
+################################################################################
+.PHONY: check-diff
+check-diff:
+	git diff --exit-code ./go.mod # check no changes
+
+################################################################################
+# Target: clean                                                                #
+################################################################################
+.PHONY: clean
+clean:
+	@-rm -rf *.out

--- a/eventmesh-server-go/README.md
+++ b/eventmesh-server-go/README.md
@@ -1,0 +1,15 @@
+EventMesh Server Go
+- Makefile tip
+ >1. use golangci-lint static code check
+ >>- install: `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest`
+ >>- `make lint`
+ 
+ >2. test code
+ >>- `make test`
+ 
+ >3. test coverage
+ >>- `make coverage`
+ 
+ >4. build code
+ >>- `make build`
+


### PR DESCRIPTION

Fixes #2863 .

### Motivation

eventmesh-server-go module add golangci-lint command in Makefile


### Modifications

modify Makefile add lint command .


### Documentation

- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? (docs)
see README.md