### PR TITLE
[ISSUE #2875] eventmesh-connector-redis:test jvm crash when using openjdk8

### DIFF
--- a/eventmesh-connector-plugin/eventmesh-connector-redis/build.gradle
+++ b/eventmesh-connector-plugin/eventmesh-connector-redis/build.gradle
@@ -50,3 +50,7 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok:1.18.22'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.22'
 }
+
+test {
+    systemProperty "io.netty.tryUnsafe", "false"
+}


### PR DESCRIPTION
Fixes #2875 .

### Motivation

eventmesh-connector-redis:test jvm crash when using openjdk8.

### Modifications

gradle test task add systemProperty "io.netty.tryUnsafe", "false".

### Documentation

- Does this pull request introduce a new feature? ( no)
- If yes, how is the feature documented? (not documented)

