### PR TITLE
[ISSUE #1538] Fixes issue with integer-based for loop in BatchMessage.java

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/grpc/protos/BatchMessage.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/grpc/protos/BatchMessage.java
@@ -1555,9 +1555,7 @@ public final class BatchMessage extends
                 (!getTopicBytes().isEmpty() ?
                         com.google.protobuf.GeneratedMessageV3.computeStringSize(3, topic_) : 0);
 
-        for (MessageItem messageItem : messageItem_) {
-            size += com.google.protobuf.CodedOutputStream.computeMessageSize(4, messageItem);
-        }
+        messageItem_.forEach(messageItem -> size += com.google.protobuf.CodedOutputStream.computeMessageSize(4, messageItem));
 
         size += unknownFields.getSerializedSize();
         memoizedSize = size;

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/grpc/protos/BatchMessage.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/grpc/protos/BatchMessage.java
@@ -1555,9 +1555,8 @@ public final class BatchMessage extends
                 (!getTopicBytes().isEmpty() ?
                         com.google.protobuf.GeneratedMessageV3.computeStringSize(3, topic_) : 0);
 
-        for (int i = 0; i < messageItem_.size(); i++) {
-            size += com.google.protobuf.CodedOutputStream
-                    .computeMessageSize(4, messageItem_.get(i));
+        for (MessageItem messageItem : messageItem_) {
+            size += com.google.protobuf.CodedOutputStream.computeMessageSize(4, messageItem);
         }
 
         size += unknownFields.getSerializedSize();

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/grpc/protos/BatchMessage.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/grpc/protos/BatchMessage.java
@@ -21,6 +21,7 @@
 package org.apache.eventmesh.common.protocol.grpc.protos;
 
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.protobuf.ByteString;
 
@@ -1542,21 +1543,15 @@ public final class BatchMessage extends
     }
 
     public int getSerializedSize() {
-        int size = memoizedSize;
-        if (size != -1) return size;
-
-        size = 0;
-        size += (header_ != null ?
-                com.google.protobuf.CodedOutputStream.computeMessageSize(1, getHeader()) : 0)
-                +
-                (!getProducerGroupBytes().isEmpty() ?
-                        com.google.protobuf.GeneratedMessageV3.computeStringSize(2, producerGroup_) : 0)
-                +
-                (!getTopicBytes().isEmpty() ?
-                        com.google.protobuf.GeneratedMessageV3.computeStringSize(3, topic_) : 0);
-
-        messageItem_.forEach(messageItem -> size += com.google.protobuf.CodedOutputStream.computeMessageSize(4, messageItem));
-
+        int size;
+        if (memoizedSize != -1) return memoizedSize;
+        size = header_ != null ?
+                com.google.protobuf.CodedOutputStream.computeMessageSize(1, getHeader()) : 0;
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, producerGroup_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, topic_);
+        size += messageItem_.stream()
+                .mapToInt(messageItem -> com.google.protobuf.CodedOutputStream.computeMessageSize(4, messageItem))
+                .sum();
         size += unknownFields.getSerializedSize();
         memoizedSize = size;
         return memoizedSize;


### PR DESCRIPTION


Fixes #1538 .

### Motivation

The method uses an integer-based for loop to iterate over a java.util.List, by calling List.get(i) each time through the loop. This can lead to poor performance and issues when using other collection types. The goal of this change is to improve performance and flexibility by using iterators or foreach loops instead.



### Modifications

Replaced the integer-based for loop with an iterator or foreach loop in the method located at org/apache/eventmesh/common/protocol/grpc/protos/BatchMessage.java line 1558 and 1560

![lines1558-1560](https://user-images.githubusercontent.com/92351152/212400661-4ea16584-819e-4544-8ec1-504ff9d87819.jpg)



### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
- If a feature is not applicable for documentation, explain why? This pull request does not introduce a new feature, it only improves the performance and flexibility of the existing code.
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation (not applicable)
