### PR TITLE
[ISSUE #2925] eventmesh-connector-plugin:eventmesh-connector-redis:test error

### DIFF
--- a/eventmesh-connector-plugin/eventmesh-connector-redis/src/test/java/org/apache/eventmesh/connector/redis/config/RedisPropertiesTest.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-redis/src/test/java/org/apache/eventmesh/connector/redis/config/RedisPropertiesTest.java
@@ -39,8 +39,8 @@ public class RedisPropertiesTest {
         Assert.assertEquals(config.getServerMasterName(), "serverMasterName-success!!!");
 
         Properties properties = new Properties();
-        properties.put("threads", "816");
-        properties.put("nettyThreads", "1816");
+        properties.put("threads", "2");
+        properties.put("nettyThreads", "2");
         Properties redissonProperties = config.getRedissonProperties();
         Assert.assertEquals(redissonProperties, properties);
     }

--- a/eventmesh-connector-plugin/eventmesh-connector-redis/src/test/resources/redis-client.properties
+++ b/eventmesh-connector-plugin/eventmesh-connector-redis/src/test/resources/redis-client.properties
@@ -17,5 +17,5 @@
 eventMesh.server.redis.serverAddress=redis://127.0.0.1:6379
 eventMesh.server.redis.serverType=SINGLE
 eventMesh.server.redis.serverMasterName=serverMasterName-success!!!
-eventMesh.server.redis.redisson.threads=816
-eventMesh.server.redis.redisson.nettyThreads=1816
+eventMesh.server.redis.redisson.threads=2
+eventMesh.server.redis.redisson.nettyThreads=2


### PR DESCRIPTION


Fixes #2925 .

### Motivation

fix :eventmesh-connector-plugin:eventmesh-connector-redis:test error.


### Modifications

modiy redis-client.properties 
eventMesh.server.redis.redisson.threads=2
eventMesh.server.redis.redisson.nettyThreads=2


### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
