### PR TITLE
[ISSUE #2646] Recomputing SerialVersionUID for BatchMesageWrapper

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/grpc/common/BatchMessageWrapper.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/grpc/common/BatchMessageWrapper.java
@@ -21,8 +21,7 @@ import org.apache.eventmesh.common.protocol.ProtocolTransportObject;
 import org.apache.eventmesh.common.protocol.grpc.protos.BatchMessage;
 
 public class BatchMessageWrapper implements ProtocolTransportObject {
-    public static final long serialVersionUID = 7658452608197650205L;
-
+    private static final long serialVersionUID = -3296467364340663768L;
     private final BatchMessage batchMessage;
 
     public BatchMessageWrapper(BatchMessage batchMessage) {


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Cloese #<XXX>`.)
-->

Fixes #2646 .

### Motivation

The computed SerialVersionUID was not a computed value. the new value is computed using Intellij IDEA



### Modifications

SerialVersionUID is recomputed for BatchMessageWrapper.java class using Intellij IDEA



### Documentation

- Does this pull request introduce a new feature?  (no)
