### PR TITLE
Issue #2715 Update ClientSessionGroupMapping.java

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/group/ClientSessionGroupMapping.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/group/ClientSessionGroupMapping.java
@@ -323,14 +323,14 @@ public class ClientSessionGroupMapping {
     private void cleanClientGroupWrapperCommon(ClientGroupWrapper clientGroupWrapper) throws Exception {
         log.info("GroupConsumerSessions size:{}",
                 clientGroupWrapper.getGroupConsumerSessions().size());
-        if (clientGroupWrapper.getGroupConsumerSessions().size() == 0) {
+        if (clientGroupWrapper.getGroupConsumerSessions()..isEmpty()) {
             shutdownClientGroupConsumer(clientGroupWrapper);
         }
 
         log.info("GroupProducerSessions size:{}",
                 clientGroupWrapper.getGroupProducerSessions().size());
-        if ((clientGroupWrapper.getGroupConsumerSessions().size() == 0)
-                && (clientGroupWrapper.getGroupProducerSessions().size() == 0)) {
+        if ((clientGroupWrapper.getGroupConsumerSessions().isEmpty())
+                && (clientGroupWrapper.getGroupProducerSessions()..isEmpty())) {
             shutdownClientGroupProducer(clientGroupWrapper);
 
             clientGroupMap.remove(clientGroupWrapper.getGroup());


### PR DESCRIPTION
Fixes #2715 

### Motivation

Top reasons to use isEmpty instead of size()
1. it is more expressive (the code is easier to read and to maintain)
2. it is faster, in some cases by orders of magnitude.


### Modifications

Changed the size() method on a collection to isEmpty()


### Documentation

- Does this pull request introduce a new feature? (no)
