### PR TITLE
[ISSUE #2649] Class defines a computed serialVersionUID that doesn't equate to the calculated value [HttpEventWrapper]

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/http/HttpEventWrapper.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/http/HttpEventWrapper.java
@@ -46,7 +46,7 @@ import io.netty.handler.codec.http.HttpVersion;
 
 public class HttpEventWrapper implements ProtocolTransportObject {
 
-    public static final long serialVersionUID = 7717419089390044263L;
+    public static final long serialVersionUID = -8547334421415366981L;
 
     private Map<String, Object> headerMap = new HashMap<>();
 


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Cloese #<XXX>`.)
-->

Fixes #2649.

### Motivation

To know more about serialVersionUID and this issue.

### Modifications

Generated a new serialVersionUID to fix this issue.

### Documentation

- Does this pull request introduce a new feature?: No
- If yes, how is the feature documented? Not applicable
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
