### PR TITLE
[ISSUE #2978] [Enhancement] Can be replaced with single 'Map.computeIfAbsent' method call[HeartBeatProcessor]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/HeartBeatProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/HeartBeatProcessor.java
@@ -152,7 +152,7 @@ public class HeartBeatProcessor implements HttpRequestProcessor {
             }
 
             final String groupTopicKey = client.getConsumerGroup() + "@" + client.getTopic();
-            List<Client> clients = tmpMap.computeIfAbsent(groupTopicKey,k -> new ArrayList<>());
+            List<Client> clients = tmpMap.computeIfAbsent(groupTopicKey, k -> new ArrayList<>());
 
             clients.add(client);
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/HeartBeatProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/HeartBeatProcessor.java
@@ -152,11 +152,7 @@ public class HeartBeatProcessor implements HttpRequestProcessor {
             }
 
             final String groupTopicKey = client.getConsumerGroup() + "@" + client.getTopic();
-            List<Client> clients = tmpMap.get(groupTopicKey);
-            if (clients == null) {
-                clients = new ArrayList<>();
-                tmpMap.put(groupTopicKey, clients);
-            }
+            List<Client> clients = tmpMap.computeIfAbsent(groupTopicKey,k -> new ArrayList<>());
 
             clients.add(client);
 


### PR DESCRIPTION
fix #2978 
 Can be replaced with single 'Map.computeIfAbsent' method call[HeartBeatProcessor]
