### PR TITLE
[ISSUE #3090] Can be replaced with 'Long.compare' [tcp RetryContext]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/session/retry/RetryContext.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/session/retry/RetryContext.java
@@ -40,13 +40,8 @@ public abstract class RetryContext implements Delayed {
     @Override
     public int compareTo(Delayed delayed) {
         RetryContext obj = (RetryContext) delayed;
-        if (this.executeTime > obj.executeTime) {
-            return 1;
-        } else if (this.executeTime == obj.executeTime) {
-            return 0;
-        } else {
-            return -1;
-        }
+        return Long.compare(this.executeTime, obj.executeTime);
+       
     }
 
     @Override


### PR DESCRIPTION
Fixes #3090 