### PR TITLE
[ISSUE #3106] Null check for dataContentMap in HttpProtocolAdaptor.java

### DIFF
--- a/eventmesh-protocol-plugin/eventmesh-protocol-http/src/main/java/org/apache/eventmesh/protocol/http/HttpProtocolAdaptor.java
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-http/src/main/java/org/apache/eventmesh/protocol/http/HttpProtocolAdaptor.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Objects;
 
 import io.cloudevents.CloudEvent;
 
@@ -101,8 +102,8 @@ public class HttpProtocolAdaptor<T extends ProtocolTransportObject>
                 new String(cloudEvent.getData().toBytes(), Constants.DEFAULT_CHARSET),
                 new TypeReference<Map<String, Object>>() {
                 });
-            String requestHeader = JsonUtils.toJSONString(dataContentMap.get(CONSTANTS_KEY_HEADERS));
-            byte[] requestBody = JsonUtils.toJSONString(dataContentMap.get(CONSTANTS_KEY_BODY)).getBytes(StandardCharsets.UTF_8);
+            String requestHeader = Objects.requireNonNull(JsonUtils.toJSONString(dataContentMap.get(CONSTANTS_KEY_HEADERS)), "Headers must not be null");
+            byte[] requestBody = Objects.requireNonNull(JsonUtils.toJSONString(dataContentMap.get(CONSTANTS_KEY_BODY)),"Body must not be null").getBytes(StandardCharsets.UTF_8);
             Map<String, Object> requestHeaderMap = JsonUtils.parseTypeReferenceObject(requestHeader, new TypeReference<Map<String, Object>>() {
             });
             String requestURI = dataContentMap.get(CONSTANTS_KEY_PATH).toString();

--- a/eventmesh-protocol-plugin/eventmesh-protocol-http/src/main/java/org/apache/eventmesh/protocol/http/HttpProtocolAdaptor.java
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-http/src/main/java/org/apache/eventmesh/protocol/http/HttpProtocolAdaptor.java
@@ -35,8 +35,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.Objects;
+import java.util.Set;
 
 import io.cloudevents.CloudEvent;
 
@@ -102,8 +102,10 @@ public class HttpProtocolAdaptor<T extends ProtocolTransportObject>
                 new String(cloudEvent.getData().toBytes(), Constants.DEFAULT_CHARSET),
                 new TypeReference<Map<String, Object>>() {
                 });
-            String requestHeader = Objects.requireNonNull(JsonUtils.toJSONString(dataContentMap.get(CONSTANTS_KEY_HEADERS)), "Headers must not be null");
-            byte[] requestBody = Objects.requireNonNull(JsonUtils.toJSONString(dataContentMap.get(CONSTANTS_KEY_BODY)),"Body must not be null").getBytes(StandardCharsets.UTF_8);
+            String requestHeader = JsonUtils.toJSONString(
+                Objects.requireNonNull(dataContentMap,"Headers must not be null").get(CONSTANTS_KEY_HEADERS));
+            byte[] requestBody = Objects.requireNonNull(
+                JsonUtils.toJSONString(dataContentMap.get(CONSTANTS_KEY_BODY)),"Body must not be null").getBytes(StandardCharsets.UTF_8);
             Map<String, Object> requestHeaderMap = JsonUtils.parseTypeReferenceObject(requestHeader, new TypeReference<Map<String, Object>>() {
             });
             String requestURI = dataContentMap.get(CONSTANTS_KEY_PATH).toString();

--- a/eventmesh-protocol-plugin/eventmesh-protocol-http/src/main/java/org/apache/eventmesh/protocol/http/HttpProtocolAdaptor.java
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-http/src/main/java/org/apache/eventmesh/protocol/http/HttpProtocolAdaptor.java
@@ -103,9 +103,9 @@ public class HttpProtocolAdaptor<T extends ProtocolTransportObject>
                 new TypeReference<Map<String, Object>>() {
                 });
             String requestHeader = JsonUtils.toJSONString(
-                Objects.requireNonNull(dataContentMap,"Headers must not be null").get(CONSTANTS_KEY_HEADERS));
+                Objects.requireNonNull(dataContentMap, "Headers must not be null").get(CONSTANTS_KEY_HEADERS));
             byte[] requestBody = Objects.requireNonNull(
-                JsonUtils.toJSONString(dataContentMap.get(CONSTANTS_KEY_BODY)),"Body must not be null").getBytes(StandardCharsets.UTF_8);
+                JsonUtils.toJSONString(dataContentMap.get(CONSTANTS_KEY_BODY)), "Body must not be null").getBytes(StandardCharsets.UTF_8);
             Map<String, Object> requestHeaderMap = JsonUtils.parseTypeReferenceObject(requestHeader, new TypeReference<Map<String, Object>>() {
             });
             String requestURI = dataContentMap.get(CONSTANTS_KEY_PATH).toString();


### PR DESCRIPTION
Fixes #3106 

Method:
public static <T> T requireNonNull(T obj, String message)

The Objects.requireNonNull() method is used to check that the values associated with the keys CONSTANTS_KEY_HEADERS and CONSTANTS_KEY_BODY are not null before calling the JsonUtils.serialize and getBytes methods on them. If either of the values is null, the method throws a NullPointerException with the specified error message.


line 105 : added requireNonNull method and message "Headers must not be null");
line 106 : added requireNonNull method and message "Bodymust not be null");



- Does this pull request introduce a new feature? (no)
