### PR TITLE
[ISSUE #3100] Field may be 'final'[ProducerManager]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/producer/ProducerManager.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/producer/ProducerManager.java
@@ -30,9 +30,9 @@ public class ProducerManager {
 
     public Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    private EventMeshGrpcServer eventMeshGrpcServer;
+    private final EventMeshGrpcServer eventMeshGrpcServer;
 
-    private ConcurrentHashMap<String, EventMeshProducer> producerTable = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, EventMeshProducer> producerTable = new ConcurrentHashMap<>();
 
     public ProducerManager(EventMeshGrpcServer eventMeshGrpcServer) {
         this.eventMeshGrpcServer = eventMeshGrpcServer;


### PR DESCRIPTION
Fixes #3100 .

Here the final keyword is used to stop the value change in eventMeshGrpcServer and producerTable

### Modifications
Made the variables final in line 33, 35

### Documentation
- Does this pull request introduce a new feature? (no)
