### PR TITLE
[ISSUE #3092] Conditions are always 'true' [OpenMessageTCPClient]

### DIFF
--- a/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/impl/openmessage/OpenMessageTCPClient.java
+++ b/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/impl/openmessage/OpenMessageTCPClient.java
@@ -97,21 +97,16 @@ public class OpenMessageTCPClient implements EventMeshTCPClient<Message> {
 
     @Override
     public void close() throws EventMeshException {
-
-        if (this.eventMeshTCPPubClient != null) {
-            try {
-                this.eventMeshTCPPubClient.close();
-            } catch (Exception e) {
-                throw new EventMeshException(e);
-            }
+        try {
+            this.eventMeshTCPPubClient.close();
+        } catch (Exception e) {
+            throw new EventMeshException(e);
         }
 
-        if (this.eventMeshTCPSubClient != null) {
-            try {
-                this.eventMeshTCPSubClient.close();
-            } catch (Exception e) {
-                throw new EventMeshException(e);
-            }
+        try {
+            this.eventMeshTCPSubClient.close();
+        } catch (Exception e) {
+            throw new EventMeshException(e);
         }
     }
 


### PR DESCRIPTION
Fixes #3092 .

### Motivation
Removed the if statements at line 101,109 as the conditions are always true so it doesn't effect the functionality.

### Documentation

- Does this pull request introduce a new feature? ( no)
