### PR TITLE
[ISSUE #3170] function argument NPE check fix

### DIFF
--- a/eventmesh-connector-plugin/eventmesh-connector-kafka/src/main/java/org/apache/eventmesh/connector/kafka/producer/ProducerImpl.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-kafka/src/main/java/org/apache/eventmesh/connector/kafka/producer/ProducerImpl.java
@@ -29,6 +29,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
 
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -80,7 +81,7 @@ public class ProducerImpl {
 
     public void send(CloudEvent cloudEvent) {
         try {
-            this.producer.send(new ProducerRecord<>(cloudEvent.getSubject(), cloudEvent));
+            this.producer.send(new ProducerRecord<>(Objects.requireNonNull(cloudEvent.getSubject()), cloudEvent));
         } catch (Exception e) {
             log.error(String.format("Send message oneway Exception, %s", cloudEvent), e);
         }


### PR DESCRIPTION
Fixes #3170.

### Motivation

Hi i'am new to opensource hoping to contribute to projects i find interesting...

Checks and throws for NPE before sending null to as an argument to the function.


### Modifications

located at:
eventmesh-connector-plugin/eventmesh-connector-kafka/src/main/java/org/apache/eventmesh/connector/kafka/producer/ProducerImpl.java line 84:53

Added the null pointer check so that it throws before sending the null as an argument.



### Documentation

- Does this pull request introduce a new feature? (no)
