### PR TITLE
[ISSUE #3168] IO streams closed, encoding set to UTF_8, test fails if file change not occurred

### DIFF
--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/file/WatchFileManagerTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/file/WatchFileManagerTest.java
@@ -22,8 +22,6 @@ import org.apache.eventmesh.common.utils.ThreadUtils;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/file/WatchFileManagerTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/file/WatchFileManagerTest.java
@@ -19,7 +19,11 @@ package org.apache.eventmesh.common.file;
 
 import org.apache.eventmesh.common.utils.ThreadUtils;
 
-import java.io.*;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -51,9 +55,9 @@ public class WatchFileManagerTest {
         WatchFileManager.registerFileChangeListener(f.getParent(), fileChangeListener);
 
         Path path = Paths.get(filePathString);
-        try(BufferedReader bufferedFileReader = Files.newBufferedReader(path, StandardCharsets.UTF_8);
-            BufferedWriter bufferedFileWriter = Files.newBufferedWriter(path, StandardCharsets.UTF_8)
-        ){
+        try (BufferedReader bufferedFileReader = Files.newBufferedReader(path, StandardCharsets.UTF_8);
+             BufferedWriter bufferedFileWriter = Files.newBufferedWriter(path, StandardCharsets.UTF_8)
+        ) {
             Properties properties = new Properties();
             properties.load(bufferedFileReader);
             properties.setProperty("eventMesh.server.newAdd", "newAdd");


### PR DESCRIPTION
Fixes #3168.

### Modifications

I have changed the api s used to read to and write from the file
previous --> Line 54 and 56
updated --> Line 54 and 55

made sure the resources are closed by enclosing it with try with resources.

made sure the test fails if it fails to read from the given file or  fails to write to it.

### Documentation

- Does this pull request introduce a new feature? (no)
