### PR TITLE
[ISSUE #3168] IO streams closed, encoding set to UTF_8, test fails if file change not occurred

### DIFF
--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/file/WatchFileManagerTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/file/WatchFileManagerTest.java
@@ -20,10 +20,13 @@ package org.apache.eventmesh.common.file;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -33,29 +36,36 @@ import org.junit.Test;
 public class WatchFileManagerTest {
 
     @Test
-    public void testWatchFile() throws IOException, InterruptedException {
-        String file = WatchFileManagerTest.class.getResource("/configuration.properties").getFile();
-        File f = new File(file);
+    public void testWatchFile() {
+        String resourceUrl = WatchFileManagerTest.class.getResource("/configuration.properties").getFile();
+        File file = new File(resourceUrl);
         final FileChangeListener fileChangeListener = new FileChangeListener() {
             @Override
             public void onChanged(FileChangeContext changeContext) {
-                Assert.assertEquals(f.getName(), changeContext.getFileName());
-                Assert.assertEquals(f.getParent(), changeContext.getDirectoryPath());
+                Assert.assertEquals(file.getName(), changeContext.getFileName());
+                Assert.assertEquals(file.getParent(), changeContext.getDirectoryPath());
             }
 
             @Override
             public boolean support(FileChangeContext changeContext) {
-                return changeContext.getWatchEvent().context().toString().contains(f.getName());
+                return changeContext.getWatchEvent().context().toString().contains(file.getName());
             }
         };
-        WatchFileManager.registerFileChangeListener(f.getParent(), fileChangeListener);
+        WatchFileManager.registerFileChangeListener(file.getParent(), fileChangeListener);
 
+        Path path = Paths.get(resourceUrl);
         Properties properties = new Properties();
-        properties.load(new BufferedReader(new FileReader(file)));
+        try (BufferedReader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+            properties.load(reader);
+        } catch (IOException e) {
+            Assert.fail("Test failed to load from file");
+        }
         properties.setProperty("eventMesh.server.newAdd", "newAdd");
-        FileWriter fw = new FileWriter(file);
-        properties.store(fw, "newAdd");
-
+        try (BufferedWriter writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
+            properties.store(writer, "newAdd");
+        } catch (IOException e) {
+            Assert.fail("Test failed to write to file");
+        }
         ThreadUtils.sleep(500, TimeUnit.MILLISECONDS);
     }
 }


### PR DESCRIPTION
Fixes #3168 



### Modifications

*Describe the modifications you've done.*

I have changed the api s used to read to and write from the file
previous --> Line 53 - 57
updated --> Line 56 - 68

made sure the resources are closed by enclosing it with try with resources.

made sure the test fails if it fails to read from the given file or fails to write to it.



### Documentation

- Does this pull request introduce a new feature? (no)
