### PR TITLE
[ISSUE #3181] The method parameter properties of the aclService is adjusted to an object parameter, providing extended fields

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/acl/Acl.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/acl/Acl.java
@@ -17,7 +17,7 @@
 
 package org.apache.eventmesh.runtime.acl;
 
-import org.apache.eventmesh.api.acl.AclPropertyKeys;
+import org.apache.eventmesh.api.acl.AclProperties;
 import org.apache.eventmesh.api.acl.AclService;
 import org.apache.eventmesh.api.exception.AclException;
 import org.apache.eventmesh.common.protocol.tcp.UserAgent;
@@ -27,7 +27,6 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 
@@ -105,16 +104,17 @@ public class Acl {
         aclService.doAclCheckInReceive(buildTcpAclProperties(remoteAddr, userAgent, topic, requestCode));
     }
 
-    private static Properties buildTcpAclProperties(String remoteAddr, UserAgent userAgent, String topic, int requestCode) {
-        Properties aclProperties = new Properties();
-        aclProperties.put(AclPropertyKeys.CLIENT_IP, remoteAddr);
-        aclProperties.put(AclPropertyKeys.USER, userAgent.getUsername());
-        aclProperties.put(AclPropertyKeys.PASSWORD, userAgent.getPassword());
-        aclProperties.put(AclPropertyKeys.SUBSYSTEM, userAgent.getSubsystem());
-        aclProperties.put(AclPropertyKeys.REQUEST_CODE, requestCode);
+    private static AclProperties buildTcpAclProperties(String remoteAddr, UserAgent userAgent, String topic, int requestCode) {
+        AclProperties aclProperties = new AclProperties();
+        aclProperties.setClientIp(remoteAddr);
+        aclProperties.setUser(userAgent.getUsername());
+        aclProperties.setPwd(userAgent.getPassword());
+        aclProperties.setSubsystem(userAgent.getSubsystem());
+        aclProperties.setRequestCode(requestCode);
         if (StringUtils.isNotBlank(topic)) {
-            aclProperties.put(AclPropertyKeys.TOPIC, topic);
+            aclProperties.setTopic(topic);
         }
+
         return aclProperties;
     }
 
@@ -143,28 +143,28 @@ public class Acl {
         aclService.doAclCheckInHeartbeat(buildHttpAclProperties(remoteAddr, user, pass, subsystem, topic, requestCode));
     }
 
-    private Properties buildHttpAclProperties(String remoteAddr, String user, String pass, String subsystem, String topic, int requestCode) {
-        Properties aclProperties = new Properties();
-        aclProperties.put(AclPropertyKeys.CLIENT_IP, remoteAddr);
-        aclProperties.put(AclPropertyKeys.USER, user);
-        aclProperties.put(AclPropertyKeys.PASSWORD, pass);
-        aclProperties.put(AclPropertyKeys.SUBSYSTEM, subsystem);
-        aclProperties.put(AclPropertyKeys.REQUEST_CODE, requestCode);
+    private AclProperties buildHttpAclProperties(String remoteAddr, String user, String pass, String subsystem, String topic, int requestCode) {
+        AclProperties aclProperties = new AclProperties();
+        aclProperties.setClientIp(remoteAddr);
+        aclProperties.setUser(user);
+        aclProperties.setPwd(pass);
+        aclProperties.setSubsystem(subsystem);
+        aclProperties.setRequestCode(requestCode);
         if (StringUtils.isNotBlank(topic)) {
-            aclProperties.put(AclPropertyKeys.TOPIC, topic);
+            aclProperties.setTopic(topic);
         }
         return aclProperties;
     }
 
-    private Properties buildHttpAclProperties(String remoteAddr, String user, String pass, String subsystem, String topic, String requestURI) {
-        Properties aclProperties = new Properties();
-        aclProperties.put(AclPropertyKeys.CLIENT_IP, remoteAddr);
-        aclProperties.put(AclPropertyKeys.USER, user);
-        aclProperties.put(AclPropertyKeys.PASSWORD, pass);
-        aclProperties.put(AclPropertyKeys.SUBSYSTEM, subsystem);
-        aclProperties.put(AclPropertyKeys.REQUEST_URI, requestURI);
+    private AclProperties buildHttpAclProperties(String remoteAddr, String user, String pass, String subsystem, String topic, String requestURI) {
+        AclProperties aclProperties = new AclProperties();
+        aclProperties.setClientIp(remoteAddr);
+        aclProperties.setUser(user);
+        aclProperties.setPwd(pass);
+        aclProperties.setSubsystem(subsystem);
+        aclProperties.setRequestURI(requestURI);
         if (StringUtils.isNotBlank(topic)) {
-            aclProperties.put(AclPropertyKeys.TOPIC, topic);
+            aclProperties.setTopic(topic);
         }
         return aclProperties;
     }

--- a/eventmesh-security-plugin/eventmesh-security-acl/src/main/java/org/apache/eventmesh/acl/impl/AclServiceImpl.java
+++ b/eventmesh-security-plugin/eventmesh-security-acl/src/main/java/org/apache/eventmesh/acl/impl/AclServiceImpl.java
@@ -17,10 +17,10 @@
 
 package org.apache.eventmesh.acl.impl;
 
+import org.apache.eventmesh.api.acl.AclProperties;
 import org.apache.eventmesh.api.acl.AclService;
 import org.apache.eventmesh.api.exception.AclException;
 
-import java.util.Properties;
 
 public class AclServiceImpl implements AclService {
     @Override
@@ -39,22 +39,22 @@ public class AclServiceImpl implements AclService {
     }
 
     @Override
-    public void doAclCheckInConnect(Properties aclProperties) throws AclException {
+    public void doAclCheckInConnect(AclProperties aclProperties) throws AclException {
         //TODO
     }
 
     @Override
-    public void doAclCheckInHeartbeat(Properties aclProperties) throws AclException {
+    public void doAclCheckInHeartbeat(AclProperties aclProperties) throws AclException {
         //TODO
     }
 
     @Override
-    public void doAclCheckInSend(Properties aclProperties) throws AclException {
+    public void doAclCheckInSend(AclProperties aclProperties) throws AclException {
         //TODO
     }
 
     @Override
-    public void doAclCheckInReceive(Properties aclProperties) throws AclException {
+    public void doAclCheckInReceive(AclProperties aclProperties) throws AclException {
         //TODO
     }
 }

--- a/eventmesh-security-plugin/eventmesh-security-acl/src/test/java/org/apache/eventmesh/acl/impl/AclServiceImplTest.java
+++ b/eventmesh-security-plugin/eventmesh-security-acl/src/test/java/org/apache/eventmesh/acl/impl/AclServiceImplTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.eventmesh.acl.impl;
 
+import org.apache.eventmesh.api.acl.AclProperties;
 import org.apache.eventmesh.api.acl.AclService;
 import org.apache.eventmesh.api.exception.AclException;
 
-import java.util.Properties;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -65,7 +65,7 @@ public class AclServiceImplTest {
     @Test
     public void testDoAclCheckInConnect() {
         try {
-            service.doAclCheckInConnect(new Properties());
+            service.doAclCheckInConnect(new AclProperties());
         } catch (AclException e) {
             Assert.fail(e.getMessage());
         }
@@ -74,7 +74,7 @@ public class AclServiceImplTest {
     @Test
     public void testDoAclCheckInHeartbeat() {
         try {
-            service.doAclCheckInHeartbeat(new Properties());
+            service.doAclCheckInHeartbeat(new AclProperties());
         } catch (AclException e) {
             Assert.fail(e.getMessage());
         }
@@ -83,7 +83,7 @@ public class AclServiceImplTest {
     @Test
     public void testDoAclCheckInSend() {
         try {
-            service.doAclCheckInSend(new Properties());
+            service.doAclCheckInSend(new AclProperties());
         } catch (AclException e) {
             Assert.fail(e.getMessage());
         }
@@ -92,7 +92,7 @@ public class AclServiceImplTest {
     @Test
     public void testDoAclCheckInReceive() {
         try {
-            service.doAclCheckInReceive(new Properties());
+            service.doAclCheckInReceive(new AclProperties());
         } catch (AclException e) {
             Assert.fail(e.getMessage());
         }

--- a/eventmesh-security-plugin/eventmesh-security-api/src/main/java/org/apache/eventmesh/api/acl/AclProperties.java
+++ b/eventmesh-security-plugin/eventmesh-security-api/src/main/java/org/apache/eventmesh/api/acl/AclProperties.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.api.acl;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class AclProperties {
+
+    private String clientIp;
+    private String user;
+    private String pwd;
+    private String subsystem;
+    private String topic;
+    private Integer requestCode;
+    private String requestURI;
+    private String token;
+    private Map<String, Object> extendedFields = new ConcurrentHashMap<>();
+
+    public String getClientIp() {
+        return clientIp;
+    }
+
+    public void setClientIp(String clientIp) {
+        this.clientIp = clientIp;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public String getPwd() {
+        return pwd;
+    }
+
+    public void setPwd(String pwd) {
+        this.pwd = pwd;
+    }
+
+    public String getSubsystem() {
+        return subsystem;
+    }
+
+    public void setSubsystem(String subsystem) {
+        this.subsystem = subsystem;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public Integer getRequestCode() {
+        return requestCode;
+    }
+
+    public void setRequestCode(Integer requestCode) {
+        this.requestCode = requestCode;
+    }
+
+    public String getRequestURI() {
+        return requestURI;
+    }
+
+    public void setRequestURI(String requestURI) {
+        this.requestURI = requestURI;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public void setExtendedField(String key, Object object) {
+        extendedFields.put(key, object);
+    }
+
+    public Object getExtendedField(String key) {
+        return extendedFields.get(key);
+    }
+
+}

--- a/eventmesh-security-plugin/eventmesh-security-api/src/main/java/org/apache/eventmesh/api/acl/AclService.java
+++ b/eventmesh-security-plugin/eventmesh-security-api/src/main/java/org/apache/eventmesh/api/acl/AclService.java
@@ -21,7 +21,6 @@ import org.apache.eventmesh.api.exception.AclException;
 import org.apache.eventmesh.spi.EventMeshExtensionType;
 import org.apache.eventmesh.spi.EventMeshSPI;
 
-import java.util.Properties;
 
 /**
  * AclService
@@ -34,12 +33,12 @@ public interface AclService {
 
     void shutdown() throws AclException;
 
-    void doAclCheckInConnect(Properties aclProperties) throws AclException;
+    void doAclCheckInConnect(AclProperties aclProperties) throws AclException;
 
-    void doAclCheckInHeartbeat(Properties aclProperties) throws AclException;
+    void doAclCheckInHeartbeat(AclProperties aclProperties) throws AclException;
 
-    void doAclCheckInSend(Properties aclProperties) throws AclException;
+    void doAclCheckInSend(AclProperties aclProperties) throws AclException;
 
-    void doAclCheckInReceive(Properties aclProperties) throws AclException;
+    void doAclCheckInReceive(AclProperties aclProperties) throws AclException;
 
 }

--- a/eventmesh-security-plugin/eventmesh-security-api/src/test/java/org/apache/eventmesh/api/acl/AclServiceTest.java
+++ b/eventmesh-security-plugin/eventmesh-security-api/src/test/java/org/apache/eventmesh/api/acl/AclServiceTest.java
@@ -19,7 +19,6 @@ package org.apache.eventmesh.api.acl;
 
 import org.apache.eventmesh.api.exception.AclException;
 
-import java.util.Properties;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -45,22 +44,22 @@ public class AclServiceTest {
         }
 
         @Override
-        public void doAclCheckInConnect(Properties aclProperties) throws AclException {
+        public void doAclCheckInConnect(AclProperties aclProperties) throws AclException {
 
         }
 
         @Override
-        public void doAclCheckInHeartbeat(Properties aclProperties) throws AclException {
+        public void doAclCheckInHeartbeat(AclProperties aclProperties) throws AclException {
 
         }
 
         @Override
-        public void doAclCheckInSend(Properties aclProperties) throws AclException {
+        public void doAclCheckInSend(AclProperties aclProperties) throws AclException {
 
         }
 
         @Override
-        public void doAclCheckInReceive(Properties aclProperties) throws AclException {
+        public void doAclCheckInReceive(AclProperties aclProperties) throws AclException {
 
         }
     }
@@ -102,7 +101,7 @@ public class AclServiceTest {
     @Test
     public void testDoAclCheckInConnect() {
         try {
-            service.doAclCheckInConnect(new Properties());
+            service.doAclCheckInConnect(new AclProperties());
         } catch (AclException e) {
             Assert.fail(e.getMessage());
         }
@@ -111,7 +110,7 @@ public class AclServiceTest {
     @Test
     public void testDoAclCheckInHeartbeat() {
         try {
-            service.doAclCheckInHeartbeat(new Properties());
+            service.doAclCheckInHeartbeat(new AclProperties());
         } catch (AclException e) {
             Assert.fail(e.getMessage());
         }
@@ -120,7 +119,7 @@ public class AclServiceTest {
     @Test
     public void testDoAclCheckInSend() {
         try {
-            service.doAclCheckInSend(new Properties());
+            service.doAclCheckInSend(new AclProperties());
         } catch (AclException e) {
             Assert.fail(e.getMessage());
         }
@@ -129,7 +128,7 @@ public class AclServiceTest {
     @Test
     public void testDoAclCheckInReceive() {
         try {
-            service.doAclCheckInReceive(new Properties());
+            service.doAclCheckInReceive(new AclProperties());
         } catch (AclException e) {
             Assert.fail(e.getMessage());
         }


### PR DESCRIPTION
Fixes #3181 

The AclService interface has been modified so that its methods can receive custom objects
AclService method field fix
![image](https://user-images.githubusercontent.com/125450203/220240453-29e66f7f-a364-4915-8701-9a46162c0d47.png)
![image](https://user-images.githubusercontent.com/125450203/220240320-b8d51eab-b9bf-439b-9343-301668062f81.png)




