### PR TITLE
[ISSUE #3150] Method prints the stack trace to the console[SubClientImpl]

### DIFF
--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/client/impl/SubClientImpl.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/client/impl/SubClientImpl.java
@@ -44,7 +44,6 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 
-
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -92,7 +91,7 @@ public class SubClientImpl extends TCPClient implements SubClient {
             task.cancel(false);
             super.close();
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("cancel close err", e);
         }
     }
 


### PR DESCRIPTION
Fixes #3150 .


### Modifications

Locating at eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/client/impl/SubClientImpl.java

- Line 47: Re-foramt according to code style;
- Line 94: Logging rather than console trace;


### Documentation

- Does this pull request introduce a new feature? (no)