### PR TITLE
[ISSUE #3245] upgrade gradle to 8.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,9 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.3"
-        classpath "io.spring.gradle:dependency-management-plugin:1.0.11.RELEASE"
-        classpath "com.github.jk1:gradle-license-report:1.17"
+        classpath "com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.13"
+        classpath "io.spring.gradle:dependency-management-plugin:1.1.0"
+        classpath "com.github.jk1:gradle-license-report:2.1"
     }
 }
 
@@ -193,9 +193,9 @@ subprojects {
 
     jacocoTestReport {
         reports {
-            xml.enabled true
-            csv.enabled false
-            html.enabled false
+            xml.required = true
+            csv.required = false
+            html.required = false
         }
     }
 
@@ -336,12 +336,12 @@ subprojects {
 
     task packageJavadoc(type: Jar, dependsOn: ['javadoc']) {
         from project.javadoc.destinationDir
-        classifier = 'javadoc'
+        destinationDirectory.set(file("$buildDir/docs"))
     }
 
     task packageSources(type: Jar) {
         from project.sourceSets.main.allSource
-        classifier = 'sources'  // either here or in artifacts block
+        destinationDirectory.set(file("$buildDir/sources"))
     }
 
     artifacts {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -17,6 +17,6 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION

Fixes #3245 .

### Motivation

upgrade Gradle 7.6 to 8.x


### Modifications

1. update spotbugs ,dependency-management,gradle-license-report plugin version.
2. adapter plugin new version  api.
3. modify gradle/wrapper/gradle-wrapper.properties to upgrade gradle version to 8.0.1


### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)

