### PR TITLE
[ISSUE #3307] Kafka Consumer Shuts Down Properly

### DIFF
--- a/eventmesh-connector-plugin/eventmesh-connector-kafka/src/main/java/org/apache/eventmesh/connector/kafka/consumer/ConsumerImpl.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-kafka/src/main/java/org/apache/eventmesh/connector/kafka/consumer/ConsumerImpl.java
@@ -83,14 +83,8 @@ public class ConsumerImpl {
     public synchronized void shutdown() {
         if (this.started.compareAndSet(true, false)) {
             // Shutdown the executor and interrupt any running tasks
-            List<Runnable> tasks = executorService.shutdownNow();
-
-            // Call a shutdown on each thread
-            for (Runnable task : tasks) {
-                if (task instanceof KafkaConsumerRunner) {
-                    ((KafkaConsumerRunner) task).shutdown();
-                }
-            }
+            kafkaConsumerRunner.shutdown();
+            executorService.shutdown();
         }
     }
 

--- a/eventmesh-connector-plugin/eventmesh-connector-kafka/src/main/java/org/apache/eventmesh/connector/kafka/consumer/ConsumerImpl.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-kafka/src/main/java/org/apache/eventmesh/connector/kafka/consumer/ConsumerImpl.java
@@ -82,7 +82,15 @@ public class ConsumerImpl {
 
     public synchronized void shutdown() {
         if (this.started.compareAndSet(true, false)) {
-            this.kafkaConsumer.close();
+            // Shutdown the executor and interrupt any running tasks
+            List<Runnable> tasks = executorService.shutdownNow();
+
+            // Call a shutdown on each thread
+            for (Runnable task : tasks) {
+                if (task instanceof KafkaConsumerRunner) {
+                    ((KafkaConsumerRunner) task).shutdown();
+                }
+            }
         }
     }
 


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Closes #<XXX>`.)
-->

Fixes #3307.

### Motivation

It is possible that the Kafka consumer will be closed twice. It will raise an IllegalStateException when being closed again.

### Modifications

Since we call `consumer.close()` in `ConsumerImpl.java`. The consumer is already closed. In the final shutdown of eventmesh, the `finally` section of code in the `KafkaConsumerRunner` will also be called, resulting in closing the consumer twice.

As a result, I modify the code to call the shutdown method in the `KafkaRunner`, and then shut down the executor to prevent the executor from running forever.


### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
