### PR TITLE
[ISSUE #3323]  Unsubscribe from a single topic

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/Constants.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/Constants.java
@@ -108,6 +108,8 @@ public class Constants {
 
     public static final String ACCESS_POINTS = "ACCESS_POINTS";
 
+    public static final String CLIENT_ADDRESS = "clientAddress";
+
     public static final String REGION = "REGION";
 
     public static final String MESSAGE_MODEL = "MESSAGE_MODEL";

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/file/WatchFileManagerTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/file/WatchFileManagerTest.java
@@ -20,10 +20,13 @@ package org.apache.eventmesh.common.file;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -33,29 +36,36 @@ import org.junit.Test;
 public class WatchFileManagerTest {
 
     @Test
-    public void testWatchFile() throws IOException, InterruptedException {
-        String file = WatchFileManagerTest.class.getResource("/configuration.properties").getFile();
-        File f = new File(file);
+    public void testWatchFile() {
+        String resourceUrl = WatchFileManagerTest.class.getResource("/configuration.properties").getFile();
+        File file = new File(resourceUrl);
         final FileChangeListener fileChangeListener = new FileChangeListener() {
             @Override
             public void onChanged(FileChangeContext changeContext) {
-                Assert.assertEquals(f.getName(), changeContext.getFileName());
-                Assert.assertEquals(f.getParent(), changeContext.getDirectoryPath());
+                Assert.assertEquals(file.getName(), changeContext.getFileName());
+                Assert.assertEquals(file.getParent(), changeContext.getDirectoryPath());
             }
 
             @Override
             public boolean support(FileChangeContext changeContext) {
-                return changeContext.getWatchEvent().context().toString().contains(f.getName());
+                return changeContext.getWatchEvent().context().toString().contains(file.getName());
             }
         };
-        WatchFileManager.registerFileChangeListener(f.getParent(), fileChangeListener);
+        WatchFileManager.registerFileChangeListener(file.getParent(), fileChangeListener);
 
+        Path path = Paths.get(resourceUrl);
         Properties properties = new Properties();
-        properties.load(new BufferedReader(new FileReader(file)));
+        try (BufferedReader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+            properties.load(reader);
+        } catch (IOException e) {
+            Assert.fail("Test failed to load from file");
+        }
         properties.setProperty("eventMesh.server.newAdd", "newAdd");
-        FileWriter fw = new FileWriter(file);
-        properties.store(fw, "newAdd");
-
+        try (BufferedWriter writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
+            properties.store(writer, "newAdd");
+        } catch (IOException e) {
+            Assert.fail("Test failed to write to file");
+        }
         ThreadUtils.sleep(500, TimeUnit.MILLISECONDS);
     }
 }

--- a/eventmesh-connector-plugin/eventmesh-connector-pulsar/src/main/java/org/apache/eventmesh/connector/pulsar/client/PulsarClientWrapper.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-pulsar/src/main/java/org/apache/eventmesh/connector/pulsar/client/PulsarClientWrapper.java
@@ -83,7 +83,7 @@ public class PulsarClientWrapper {
     }
 
     public void publish(CloudEvent cloudEvent, SendCallback sendCallback) {
-        String topic = cloudEvent.getSubject();
+        String topic = config.getTopicPrefix() + cloudEvent.getSubject();
         Producer<byte[]> producer = producerMap.computeIfAbsent(topic, k -> createProducer(topic));
         try {
             byte[] serializedCloudEvent = EventFormatProvider

--- a/eventmesh-connector-plugin/eventmesh-connector-pulsar/src/main/java/org/apache/eventmesh/connector/pulsar/constant/PulsarConstant.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-pulsar/src/main/java/org/apache/eventmesh/connector/pulsar/constant/PulsarConstant.java
@@ -15,28 +15,9 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.connector.pulsar.config;
+package org.apache.eventmesh.connector.pulsar.constant;
 
-import org.apache.eventmesh.common.config.Config;
-import org.apache.eventmesh.common.config.ConfigFiled;
+public class PulsarConstant {
 
-import lombok.Getter;
-import lombok.Setter;
-
-@Getter
-@Setter
-@Config(prefix = "eventMesh.server.pulsar")
-public class ClientConfiguration {
-
-    @ConfigFiled(field = "service")
-    private String serviceAddr;
-
-    @ConfigFiled(field = "authPlugin")
-    private String authPlugin;
-
-    @ConfigFiled(field = "authParams")
-    private String authParams;
-
-    @ConfigFiled(field = "topicPrefix")
-    private String topicPrefix;
+    public static final String KEY_SEPARATOR = "/";
 }

--- a/eventmesh-connector-plugin/eventmesh-connector-pulsar/src/main/java/org/apache/eventmesh/connector/pulsar/consumer/PulsarConsumerImpl.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-pulsar/src/main/java/org/apache/eventmesh/connector/pulsar/consumer/PulsarConsumerImpl.java
@@ -26,14 +26,18 @@ import org.apache.eventmesh.api.exception.ConnectorRuntimeException;
 import org.apache.eventmesh.common.Constants;
 import org.apache.eventmesh.common.config.Config;
 import org.apache.eventmesh.connector.pulsar.config.ClientConfiguration;
+import org.apache.eventmesh.connector.pulsar.constant.PulsarConstant;
 
 import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.MessageListener;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.SubscriptionMode;
+import org.apache.pulsar.client.api.SubscriptionType;
 
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.cloudevents.CloudEvent;
@@ -45,6 +49,7 @@ import com.google.common.base.Preconditions;
 
 import lombok.extern.slf4j.Slf4j;
 
+
 @Slf4j
 @Config(field = "clientConfiguration")
 public class PulsarConsumerImpl implements Consumer {
@@ -52,8 +57,9 @@ public class PulsarConsumerImpl implements Consumer {
     private final AtomicBoolean started = new AtomicBoolean(false);
     private Properties properties;
     private PulsarClient pulsarClient;
-    private org.apache.pulsar.client.api.Consumer<byte[]> consumer;
     private EventListener eventListener;
+
+    private ConcurrentHashMap<String, org.apache.pulsar.client.api.Consumer<byte[]>> consumerMap = new ConcurrentHashMap<>();
 
     /**
      * Unified configuration class corresponding to pulsar-client.properties
@@ -91,47 +97,60 @@ public class PulsarConsumerImpl implements Consumer {
 
     @Override
     public void subscribe(String topic) throws Exception {
-
+        String subTopic = clientConfiguration.getTopicPrefix() + topic;
         if (pulsarClient == null) {
             throw new ConnectorRuntimeException(
-                 String.format("Cann't find the pulsar client for topic: %s", topic));
+                String.format("Cann't find the pulsar client for topic: %s", subTopic));
         }
 
         EventMeshAsyncConsumeContext consumeContext = new EventMeshAsyncConsumeContext() {
             @Override
             public void commit(EventMeshAction action) {
-                log.debug("message action: {} for topic: {}", action.name(), topic);
+                log.debug("message action: {} for topic: {}", action.name(), subTopic);
             }
         };
 
-        consumer = pulsarClient.newConsumer()
-            .topic(topic)
+        SubscriptionType type = SubscriptionType.Shared;
+
+        String consumerKey = topic + PulsarConstant.KEY_SEPARATOR + properties.getProperty(Constants.CONSUMER_GROUP)
+            + PulsarConstant.KEY_SEPARATOR + properties.getProperty(Constants.CLIENT_ADDRESS);
+        org.apache.pulsar.client.api.Consumer<byte[]> consumer = pulsarClient.newConsumer()
+            .topic(subTopic)
             .subscriptionName(properties.getProperty(Constants.CONSUMER_GROUP))
+            .subscriptionMode(SubscriptionMode.Durable)
+            .subscriptionType(type)
             .messageListener(
-              (MessageListener<byte[]>) (ackConsumer, msg) -> {
-                  CloudEvent cloudEvent = EventFormatProvider
-                      .getInstance()
-                      .resolveFormat(JsonFormat.CONTENT_TYPE)
-                      .deserialize(msg.getData());
-                  eventListener.consume(cloudEvent, consumeContext);
-                  try {
-                      ackConsumer.acknowledge(msg);
-                  } catch (PulsarClientException ex) {
-                      throw new ConnectorRuntimeException(
-                        String.format("Failed to unsubscribe the topic:%s with exception: %s", topic, ex.getMessage()));
-                  } catch (EventDeserializationException ex) {
-                      log.warn("The Message isn't json format, with exception:{}", ex.getMessage());
-                  }
-              }).subscribe();
+                (MessageListener<byte[]>) (ackConsumer, msg) -> {
+                    CloudEvent cloudEvent = EventFormatProvider
+                        .getInstance()
+                        .resolveFormat(JsonFormat.CONTENT_TYPE)
+                        .deserialize(msg.getData());
+                    eventListener.consume(cloudEvent, consumeContext);
+                    try {
+                        ackConsumer.acknowledge(msg);
+                    } catch (PulsarClientException ex) {
+                        throw new ConnectorRuntimeException(
+                            String.format("Failed to unsubscribe the topic:%s with exception: %s", subTopic, ex.getMessage()));
+                    } catch (EventDeserializationException ex) {
+                        log.warn("The Message isn't json format, with exception:{}", ex.getMessage());
+                    }
+                }).subscribe();
+
+        consumerMap.putIfAbsent(consumerKey, consumer);
+
     }
 
     @Override
     public void unsubscribe(String topic) {
         try {
+            String consumerKey = topic + PulsarConstant.KEY_SEPARATOR + properties.getProperty(Constants.CONSUMER_GROUP)
+                + PulsarConstant.KEY_SEPARATOR + properties.getProperty(Constants.CLIENT_ADDRESS);
+            org.apache.pulsar.client.api.Consumer<byte[]> consumer = consumerMap.get(consumerKey);
             consumer.unsubscribe();
+            consumerMap.remove(consumerKey);
         } catch (PulsarClientException ex) {
             throw new ConnectorRuntimeException(
-              String.format("Failed to unsubscribe the topic:%s with exception: %s", topic, ex.getMessage()));
+                String.format("Failed to unsubscribe the topic:%s with exception: %s", topic, ex.getMessage()));
         }
     }
 
@@ -158,11 +177,20 @@ public class PulsarConsumerImpl implements Consumer {
     public void shutdown() {
         this.started.compareAndSet(true, false);
         try {
-            this.consumer.close();
+
+            consumerMap.forEach((key, consumer) -> {
+                try {
+                    consumer.close();
+                } catch (PulsarClientException e) {
+                    throw new ConnectorRuntimeException(
+                        String.format("Failed to close the pulsar consumer with exception: %s", e.getMessage()));
+                }
+            });
             this.pulsarClient.close();
+            consumerMap.clear();
         } catch (PulsarClientException ex) {
             throw new ConnectorRuntimeException(
-              String.format("Failed to close the pulsar client with exception: %s", ex.getMessage()));
+                String.format("Failed to close the pulsar client with exception: %s", ex.getMessage()));
         }
     }
 


### PR DESCRIPTION
### Motivation

Manage subscribed topics uniformly. When unsubscribing, you can unsubscribe a single topic



### Modifications
Add consumermap to manage all the consumer of pulsar. The consumer has topic information. When adding a subscription, add the consumer into the consumermap. When canceling the subscription, delete the corresponding consumer from it



### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
