### PR TITLE
[ISSUE #3491] Refactor class StandaloneAdmin and RocketMQAdmin

### DIFF
--- a/eventmesh-storage/eventmesh-storage-api/src/main/java/org/apache/eventmesh/api/admin/Admin.java
+++ b/eventmesh-storage/eventmesh-storage-api/src/main/java/org/apache/eventmesh/api/admin/Admin.java
@@ -37,7 +37,7 @@ public interface Admin extends LifeCycle {
     /**
      * Initializes admin api service.
      */
-    void init(Properties keyValue) throws Exception;
+    void init(Properties properties) throws Exception;
 
     /**
      * Get the list of topics.

--- a/eventmesh-storage/eventmesh-storage-rocketmq/src/main/java/org/apache/eventmesh/storage/rocketmq/admin/RocketMQAdmin.java
+++ b/eventmesh-storage/eventmesh-storage-rocketmq/src/main/java/org/apache/eventmesh/storage/rocketmq/admin/RocketMQAdmin.java
@@ -59,7 +59,7 @@ public class RocketMQAdmin implements Admin {
     private int numOfQueue = 4;
     private int queuePermission = 6;
 
-    public RocketMQAdmin(Properties properties) {
+    public RocketMQAdmin() {
         isStarted = new AtomicBoolean(false);
 
         ConfigService configService = ConfigService.getInstance();
@@ -98,7 +98,8 @@ public class RocketMQAdmin implements Admin {
     }
 
     @Override
-    public void init(Properties keyValue) throws Exception {
+    public void init(Properties properties) {
+
     }
 
     @Override
@@ -163,11 +164,11 @@ public class RocketMQAdmin implements Admin {
     }
 
     @Override
-    public List<CloudEvent> getEvent(String topicName, int offset, int length) throws Exception {
+    public List<CloudEvent> getEvent(String topicName, int offset, int length) {
         return null;
     }
 
     @Override
-    public void publish(CloudEvent cloudEvent) throws Exception {
+    public void publish(CloudEvent cloudEvent) {
     }
 }

--- a/eventmesh-storage/eventmesh-storage-rocketmq/src/main/java/org/apache/eventmesh/storage/rocketmq/admin/RocketMQAdminAdaptor.java
+++ b/eventmesh-storage/eventmesh-storage-rocketmq/src/main/java/org/apache/eventmesh/storage/rocketmq/admin/RocketMQAdminAdaptor.java
@@ -29,9 +29,10 @@ import io.cloudevents.CloudEvent;
 
 public class RocketMQAdminAdaptor implements Admin {
 
-    private RocketMQAdmin admin;
+    private final RocketMQAdmin admin;
 
     public RocketMQAdminAdaptor() {
+        admin = new RocketMQAdmin();
     }
 
     @Override
@@ -55,8 +56,8 @@ public class RocketMQAdminAdaptor implements Admin {
     }
 
     @Override
-    public void init(Properties keyValue) throws Exception {
-        admin = new RocketMQAdmin(keyValue);
+    public void init(Properties properties) throws Exception {
+        admin.init(properties);
     }
 
     @Override
@@ -75,12 +76,12 @@ public class RocketMQAdminAdaptor implements Admin {
     }
 
     @Override
-    public List<CloudEvent> getEvent(String topicName, int offset, int length) throws Exception {
+    public List<CloudEvent> getEvent(String topicName, int offset, int length) {
         return admin.getEvent(topicName, offset, length);
     }
 
     @Override
-    public void publish(CloudEvent cloudEvent) throws Exception {
+    public void publish(CloudEvent cloudEvent) {
         admin.publish(cloudEvent);
     }
 }

--- a/eventmesh-storage/eventmesh-storage-standalone/src/main/java/org/apache/eventmesh/storage/standalone/admin/StandaloneAdmin.java
+++ b/eventmesh-storage/eventmesh-storage-standalone/src/main/java/org/apache/eventmesh/storage/standalone/admin/StandaloneAdmin.java
@@ -37,10 +37,9 @@ import io.cloudevents.CloudEvent;
 public class StandaloneAdmin implements Admin {
 
     private final AtomicBoolean isStarted;
-
     private final StandaloneBroker standaloneBroker;
 
-    public StandaloneAdmin(Properties properties) {
+    public StandaloneAdmin() {
         this.standaloneBroker = StandaloneBroker.getInstance();
         this.isStarted = new AtomicBoolean(false);
     }
@@ -66,20 +65,21 @@ public class StandaloneAdmin implements Admin {
     }
 
     @Override
-    public void init(Properties keyValue) throws Exception {
+    public void init(Properties properties) throws Exception {
+
     }
 
     @Override
     public List<TopicProperties> getTopic() throws Exception {
         ConcurrentHashMap<TopicMetadata, MessageQueue> messageContainer = this.standaloneBroker.getMessageContainer();
         List<TopicProperties> topicList = new ArrayList<>();
-        for (TopicMetadata topicMetadata : messageContainer.keySet()) {
+        messageContainer.keySet().forEach(topicMetadata -> {
             MessageQueue messageQueue = messageContainer.get(topicMetadata);
             topicList.add(new TopicProperties(
                 topicMetadata.getTopicName(),
                 messageQueue.getPutIndex() - messageQueue.getTakeIndex()
             ));
-        }
+        });
         topicList.sort(Comparator.comparing(t -> t.name));
         return topicList;
     }

--- a/eventmesh-storage/eventmesh-storage-standalone/src/main/java/org/apache/eventmesh/storage/standalone/admin/StandaloneAdminAdaptor.java
+++ b/eventmesh-storage/eventmesh-storage-standalone/src/main/java/org/apache/eventmesh/storage/standalone/admin/StandaloneAdminAdaptor.java
@@ -29,9 +29,10 @@ import io.cloudevents.CloudEvent;
 
 public class StandaloneAdminAdaptor implements Admin {
 
-    private StandaloneAdmin admin;
+    private final StandaloneAdmin admin;
 
     public StandaloneAdminAdaptor() {
+        admin = new StandaloneAdmin();
     }
 
     @Override
@@ -55,8 +56,8 @@ public class StandaloneAdminAdaptor implements Admin {
     }
 
     @Override
-    public void init(Properties keyValue) throws Exception {
-        admin = new StandaloneAdmin(keyValue);
+    public void init(Properties properties) throws Exception {
+        admin.init(properties);
     }
 
     @Override

--- a/eventmesh-storage/eventmesh-storage-standalone/src/test/java/org/apache/eventmesh/storage/standalone/admin/StandaloneAdminTest.java
+++ b/eventmesh-storage/eventmesh-storage-standalone/src/test/java/org/apache/eventmesh/storage/standalone/admin/StandaloneAdminTest.java
@@ -30,7 +30,6 @@ import org.apache.eventmesh.storage.standalone.broker.StandaloneBroker;
 import org.apache.eventmesh.storage.standalone.broker.model.MessageEntity;
 
 import java.util.List;
-import java.util.Properties;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -115,7 +114,7 @@ public class StandaloneAdminTest {
         try (MockedStatic<StandaloneBroker> standaloneBrokerMockedStatic = Mockito.mockStatic(StandaloneBroker.class)) {
             standaloneBrokerMockedStatic.when(StandaloneBroker::getInstance).thenReturn(standaloneBroker);
             Mockito.when(standaloneBroker.getMessageContainer()).thenReturn(createDefaultMessageContainer());
-            standaloneAdmin = new StandaloneAdmin(new Properties());
+            standaloneAdmin = new StandaloneAdmin();
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-eventmesh/issues/3491

### Motivation

Make some refactoring for class `StandaloneAdmin` and `RocketMQAdmin`.  We can try this, but th will need more refactoring and some discussion before.

- Use properties or
- If not used, then delete it
- Segregate the `Admin` interface by creating an interface `Initialize` that contain the `void init(Properties properties)` method.

### Modifications

Remove the `Propertie` parameter from the constructor.

### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
